### PR TITLE
feat: add SSLCommerz sandbox payment integration

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ClassModule } from './classes/class.module';
 import { SubscriptionModule } from './subscriptions/subscription.module';
 import { SubjectModule } from './subjects/subject.module';
 import { ProctoringModule } from './proctoring/proctoring.module';
+import { PaymentModule } from './modules/payment/payment.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { ProctoringModule } from './proctoring/proctoring.module';
     SubscriptionModule,
     SubjectModule,
     ProctoringModule,
+    PaymentModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/payment/README.md
+++ b/backend/src/modules/payment/README.md
@@ -1,0 +1,139 @@
+# SSLCommerz Payment Module (Sandbox)
+
+Self-contained NestJS module for SSLCommerz sandbox payments: session creation, validation-API verification, IPN reconciliation, and gateway callbacks.
+
+All routes are served under the global prefix and URI version, e.g. `POST /api/v1/payments/initiate`.
+
+## Structure
+
+```
+src/modules/payment/
+├── payment.module.ts
+├── payment.controller.ts
+├── payment.service.ts
+├── dto/
+│   ├── initiate-payment.dto.ts
+│   ├── verify-payment.dto.ts
+│   └── sslcommerz-callback.dto.ts
+├── interfaces/
+│   └── sslcommerz.interface.ts
+├── entities/
+│   └── payment.entity.ts
+└── enums/
+    └── payment-status.enum.ts
+```
+
+## Environment Variables
+
+| Variable | Description | Example |
+| --- | --- | --- |
+| `SSL_STORE_ID` | Sandbox store id | `magne6a3d8f92c572f` |
+| `SSL_STORE_PASSWORD` | Sandbox store password | `magne6a3d8f92c572f@ssl` |
+| `SSL_SESSION_API` | Session (initiate) API | `https://sandbox.sslcommerz.com/gwprocess/v4/api.php` |
+| `SSL_VALIDATION_API` | Validation API | `https://sandbox.sslcommerz.com/validator/api/validationserverAPI.php` |
+| `BACKEND_BASE_URL` | Public backend base URL (used to build `ipn_url`) | `http://localhost:5000` |
+| `FRONTEND_BASE_URL` | Frontend base URL (used to build success/fail/cancel URLs) | `http://localhost:3000` |
+
+No credentials or URLs are hardcoded; everything is read via `ConfigService`.
+
+> IPN needs a public URL. For local testing, expose the backend with ngrok and set `BACKEND_BASE_URL` to the ngrok URL so `ipn_url` is reachable.
+
+## Payment Status
+
+`PENDING` → `PAID` | `FAILED` | `CANCELLED`
+
+A `PAID` payment is terminal and is never downgraded by later callbacks.
+
+## Callback URLs sent to the gateway
+
+- `success_url` = `FRONTEND_BASE_URL/payment/success`
+- `fail_url` = `FRONTEND_BASE_URL/payment/fail`
+- `cancel_url` = `FRONTEND_BASE_URL/payment/cancel`
+- `ipn_url` = `BACKEND_BASE_URL/api/v1/payments/ipn`
+
+The backend `success`/`fail`/`cancel` endpoints are also provided for server-side use; if you later point the gateway directly at the backend, success always re-validates through the validation API.
+
+## Endpoints
+
+All non-callback responses are wrapped by the global interceptor as:
+
+```json
+{ "statusCode": 201, "message": "...", "payload": { }, "error": false }
+```
+
+### POST /api/v1/payments/initiate
+
+Request:
+
+```json
+{
+  "orderId": "ORDER_123",
+  "amount": 1000,
+  "customer": { "name": "John Doe", "email": "john@example.com", "phone": "017xxxxxxxx" },
+  "productName": "Premium Subscription",
+  "productCategory": "subscription"
+}
+```
+
+Response `payload`:
+
+```json
+{
+  "paymentId": "0f0b...uuid",
+  "orderId": "ORDER_123",
+  "transactionId": "TT_LZ3K9_8F21AB0C",
+  "amount": 1000,
+  "currency": "BDT",
+  "gatewayPageUrl": "https://sandbox.sslcommerz.com/EasyCheckOut/..."
+}
+```
+
+The frontend redirects the user to `gatewayPageUrl`.
+
+### POST /api/v1/payments/verify
+
+Called by the frontend success page. Provide `val_id` (preferred) or `transactionId`:
+
+```json
+{ "val_id": "2406...", "transactionId": "TT_LZ3K9_8F21AB0C" }
+```
+
+Response `payload` is the updated payment (status `PAID` on success). Idempotent — calling again returns the same `PAID` record.
+
+### POST /api/v1/payments/ipn
+
+Receives the gateway's urlencoded body (`tran_id`, `val_id`, `status`, ...). Verifies through the validation API and reconciles status. Idempotent. Returns `{ received: true, status }`.
+
+### POST /api/v1/payments/success | /fail | /cancel
+
+Server-side gateway callbacks (urlencoded). `success` re-validates before marking `PAID`; `fail`/`cancel` mark the payment only if still `PENDING`.
+
+### GET /api/v1/payments/:transactionId
+
+Returns the stored payment by `tran_id` (status polling / debugging).
+
+## Validation rules
+
+- Only `VALID` or `VALIDATED` validation statuses settle a payment.
+- Validated amount must match the recorded amount (tolerance 0.01).
+- Validated `tran_id` must match the stored `tran_id`.
+- Frontend success is never trusted without a validation-API check.
+
+## Idempotency & consistency
+
+- Settlement and terminal transitions run inside a DB transaction with a `pessimistic_write` row lock, so concurrent verify/IPN requests cannot create inconsistent states.
+- Already-`PAID` payments short-circuit (no re-processing).
+- Raw `gatewayResponse` and `validationResponse` are stored as JSONB for debugging.
+
+## Sandbox testing
+
+1. Set the env vars above (sandbox credentials are already provided in `.env`).
+2. Start the backend: `npm run start:dev` (listens on `APP_PORT`, default 5000).
+3. `POST /api/v1/payments/initiate` and open the returned `gatewayPageUrl`.
+4. Complete the sandbox payment; the gateway redirects to the frontend pages.
+5. On the success page, call `POST /api/v1/payments/verify` with the `val_id` from the redirect query string.
+6. (Optional) Test IPN by exposing the backend via ngrok and setting `BACKEND_BASE_URL` to the ngrok URL.
+
+## Database entity (`payments`)
+
+`id`, `orderId`, `transactionId` (unique), `amount`, `currency`, `status`, `sslValId`, `paymentMethod`, `customerName`, `customerEmail`, `customerPhone`, `gatewayResponse` (JSONB), `validationResponse` (JSONB), `createdAt`, `updatedAt`.

--- a/backend/src/modules/payment/dto/initiate-payment.dto.ts
+++ b/backend/src/modules/payment/dto/initiate-payment.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class PaymentCustomerDto {
+  @ApiProperty({ example: 'John Doe' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: 'john@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ example: '017xxxxxxxx' })
+  @IsString()
+  @IsNotEmpty()
+  phone: string;
+}
+
+export class InitiatePaymentDto {
+  @ApiProperty({ example: 'ORDER_123' })
+  @IsString()
+  @IsNotEmpty()
+  orderId: string;
+
+  @ApiProperty({ example: 1000, minimum: 1 })
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(1)
+  @Type(() => Number)
+  amount: number;
+
+  @ApiProperty({ type: PaymentCustomerDto })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => PaymentCustomerDto)
+  customer: PaymentCustomerDto;
+
+  @ApiProperty({ required: false, example: 'Premium Subscription' })
+  @IsOptional()
+  @IsString()
+  productName?: string;
+
+  @ApiProperty({ required: false, example: 'subscription' })
+  @IsOptional()
+  @IsString()
+  productCategory?: string;
+}

--- a/backend/src/modules/payment/dto/sslcommerz-callback.dto.ts
+++ b/backend/src/modules/payment/dto/sslcommerz-callback.dto.ts
@@ -1,0 +1,39 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+/**
+ * SSLCommerz POSTs an application/x-www-form-urlencoded body to the
+ * success/fail/cancel/ipn URLs. Only the fields used by the integration are
+ * declared; the full raw body is read separately for debugging/storage.
+ */
+export class SslCommerzCallbackDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  tran_id?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  val_id?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  amount?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  card_type?: string;
+}

--- a/backend/src/modules/payment/dto/verify-payment.dto.ts
+++ b/backend/src/modules/payment/dto/verify-payment.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, ValidateIf } from 'class-validator';
+
+/**
+ * Verification can be requested by val_id (preferred, returned by the gateway)
+ * or by our own transactionId (tran_id). At least one must be present.
+ */
+export class VerifyPaymentDto {
+  @ApiPropertyOptional({ description: 'SSLCommerz validation id', example: 'sandbox_val_123' })
+  @ValidateIf((dto: VerifyPaymentDto) => !dto.transactionId)
+  @IsString()
+  val_id?: string;
+
+  @ApiPropertyOptional({ description: 'Our transaction id (tran_id)', example: 'TT_lz3k_8f21' })
+  @ValidateIf((dto: VerifyPaymentDto) => !dto.val_id)
+  @IsString()
+  transactionId?: string;
+}

--- a/backend/src/modules/payment/entities/payment.entity.ts
+++ b/backend/src/modules/payment/entities/payment.entity.ts
@@ -1,0 +1,80 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { PaymentStatusEnum } from '../enums/payment-status.enum';
+
+@Entity('payments')
+export class PaymentEntity {
+  @ApiProperty({ description: 'Internal payment UUID' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Caller-supplied order identifier' })
+  @Index()
+  @Column({ name: 'order_id', type: 'varchar', length: 255 })
+  orderId: string;
+
+  @ApiProperty({ description: 'Unique gateway transaction id (tran_id)' })
+  @Index({ unique: true })
+  @Column({ name: 'transaction_id', type: 'varchar', length: 64, unique: true })
+  transactionId: string;
+
+  @ApiProperty({ description: 'Payment amount' })
+  @Column({ name: 'amount', type: 'decimal', precision: 12, scale: 2 })
+  amount: number;
+
+  @ApiProperty({ description: 'ISO currency code' })
+  @Column({ name: 'currency', type: 'varchar', length: 10, default: 'BDT' })
+  currency: string;
+
+  @ApiProperty({ description: 'Payment status', enum: PaymentStatusEnum })
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: PaymentStatusEnum,
+    default: PaymentStatusEnum.PENDING,
+  })
+  status: PaymentStatusEnum;
+
+  @ApiPropertyOptional({ description: 'SSLCommerz validation id (val_id)' })
+  @Column({ name: 'ssl_val_id', type: 'varchar', length: 255, nullable: true })
+  sslValId: string | null;
+
+  @ApiPropertyOptional({ description: 'Resolved payment method / card type' })
+  @Column({ name: 'payment_method', type: 'varchar', length: 100, nullable: true })
+  paymentMethod: string | null;
+
+  @ApiPropertyOptional({ description: 'Customer name' })
+  @Column({ name: 'customer_name', type: 'varchar', length: 255, nullable: true })
+  customerName: string | null;
+
+  @ApiPropertyOptional({ description: 'Customer email' })
+  @Column({ name: 'customer_email', type: 'varchar', length: 255, nullable: true })
+  customerEmail: string | null;
+
+  @ApiPropertyOptional({ description: 'Customer phone' })
+  @Column({ name: 'customer_phone', type: 'varchar', length: 32, nullable: true })
+  customerPhone: string | null;
+
+  @ApiPropertyOptional({ description: 'Raw session/gateway response for debugging' })
+  @Column({ name: 'gateway_response', type: 'jsonb', nullable: true })
+  gatewayResponse: Record<string, unknown> | null;
+
+  @ApiPropertyOptional({ description: 'Raw validation response for debugging' })
+  @Column({ name: 'validation_response', type: 'jsonb', nullable: true })
+  validationResponse: Record<string, unknown> | null;
+
+  @ApiProperty({ description: 'Created timestamp' })
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Updated timestamp' })
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/payment/enums/payment-status.enum.ts
+++ b/backend/src/modules/payment/enums/payment-status.enum.ts
@@ -1,0 +1,6 @@
+export enum PaymentStatusEnum {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}

--- a/backend/src/modules/payment/interfaces/sslcommerz.interface.ts
+++ b/backend/src/modules/payment/interfaces/sslcommerz.interface.ts
@@ -1,0 +1,50 @@
+export interface SslCommerzConfig {
+  storeId: string;
+  storePassword: string;
+  sessionApi: string;
+  validationApi: string;
+  backendBaseUrl: string;
+  frontendBaseUrl: string;
+}
+
+/**
+ * Response returned by the SSLCommerz session (initiate) API.
+ * Only the fields the integration relies on are typed; the rest are kept for debugging.
+ */
+export interface SslSessionResponse {
+  status: string;
+  failedreason?: string;
+  sessionkey?: string;
+  GatewayPageURL?: string;
+  redirectGatewayURL?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Response returned by the SSLCommerz validation API.
+ */
+export interface SslValidationResponse {
+  status: string;
+  tran_id?: string;
+  val_id?: string;
+  amount?: string;
+  store_amount?: string;
+  currency?: string;
+  card_type?: string;
+  card_issuer?: string;
+  risk_level?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Common shape of the form-encoded body SSLCommerz POSTs to callback/IPN URLs.
+ */
+export interface SslCallbackPayload {
+  tran_id?: string;
+  val_id?: string;
+  amount?: string;
+  currency?: string;
+  status?: string;
+  card_type?: string;
+  [key: string]: unknown;
+}

--- a/backend/src/modules/payment/payment.controller.ts
+++ b/backend/src/modules/payment/payment.controller.ts
@@ -1,0 +1,103 @@
+import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { PaymentService } from './payment.service';
+import { InitiatePaymentDto } from './dto/initiate-payment.dto';
+import { VerifyPaymentDto } from './dto/verify-payment.dto';
+import { SslCommerzCallbackDto } from './dto/sslcommerz-callback.dto';
+import { SslCallbackPayload } from './interfaces/sslcommerz.interface';
+
+@ApiTags('Payments')
+@Controller({ path: 'payments', version: '1' })
+export class PaymentController {
+  constructor(private readonly paymentService: PaymentService) {}
+
+  @Post('initiate')
+  @ApiOperation({
+    summary: 'Initiate a payment',
+    description:
+      'Creates a PENDING payment, requests an SSLCommerz session, and returns the GatewayPageURL for redirection.',
+  })
+  @ApiResponse({ status: 201, description: 'Payment session created' })
+  async initiate(@Body() dto: InitiatePaymentDto) {
+    const payload = await this.paymentService.initiatePayment(dto);
+    return { message: 'Payment session created successfully', payload };
+  }
+
+  @Post('verify')
+  @ApiOperation({
+    summary: 'Verify a payment',
+    description:
+      'Confirms a payment through the SSLCommerz validation API. Idempotent: a PAID payment is returned unchanged.',
+  })
+  @ApiResponse({ status: 201, description: 'Payment verified' })
+  async verify(@Body() dto: VerifyPaymentDto) {
+    const payment = await this.paymentService.verifyPayment({
+      transactionId: dto.transactionId,
+      valId: dto.val_id,
+    });
+    return { message: 'Payment verified successfully', payload: payment };
+  }
+
+  @Post('ipn')
+  @ApiOperation({
+    summary: 'SSLCommerz IPN handler',
+    description:
+      'Server-to-server notification. Verifies via the validation API and reconciles status if the frontend callback was missed. Requires a public URL (ngrok/staging).',
+  })
+  @ApiResponse({ status: 201, description: 'IPN acknowledged' })
+  async ipn(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+    const payload = this.mergeCallback(dto, req);
+    const result = await this.paymentService.handleIpn(payload);
+    return { message: 'IPN processed', payload: result };
+  }
+
+  @Post('success')
+  @ApiOperation({
+    summary: 'Gateway success callback',
+    description:
+      'Optional server-side success handler. Always re-validates through the validation API before marking PAID.',
+  })
+  @ApiResponse({ status: 201, description: 'Success callback processed' })
+  async success(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+    const payload = this.mergeCallback(dto, req);
+    const payment = await this.paymentService.handleSuccessCallback(payload);
+    return { message: 'Payment success processed', payload: payment };
+  }
+
+  @Post('fail')
+  @ApiOperation({ summary: 'Gateway fail callback' })
+  @ApiResponse({ status: 201, description: 'Fail callback processed' })
+  async fail(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+    const payload = this.mergeCallback(dto, req);
+    const payment = await this.paymentService.handleFailCallback(payload);
+    return { message: 'Payment failure processed', payload: payment };
+  }
+
+  @Post('cancel')
+  @ApiOperation({ summary: 'Gateway cancel callback' })
+  @ApiResponse({ status: 201, description: 'Cancel callback processed' })
+  async cancel(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+    const payload = this.mergeCallback(dto, req);
+    const payment = await this.paymentService.handleCancelCallback(payload);
+    return { message: 'Payment cancellation processed', payload: payment };
+  }
+
+  @Get(':transactionId')
+  @ApiOperation({ summary: 'Get payment by transaction id' })
+  @ApiParam({ name: 'transactionId', description: 'Gateway transaction id (tran_id)' })
+  @ApiResponse({ status: 200, description: 'Payment retrieved' })
+  async getByTransactionId(@Param('transactionId') transactionId: string) {
+    const payment = await this.paymentService.getByTransactionId(transactionId);
+    return { message: 'Payment retrieved successfully', payload: payment };
+  }
+
+  /**
+   * SSLCommerz sends an urlencoded body. The validated DTO provides typed access
+   * to the fields we use, while the raw body preserves every field for storage.
+   */
+  private mergeCallback(dto: SslCommerzCallbackDto, req: Request): SslCallbackPayload {
+    const rawBody = (req.body ?? {}) as Record<string, unknown>;
+    return { ...rawBody, ...dto };
+  }
+}

--- a/backend/src/modules/payment/payment.module.ts
+++ b/backend/src/modules/payment/payment.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PaymentEntity } from './entities/payment.entity';
+import { PaymentController } from './payment.controller';
+import { PaymentService } from './payment.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PaymentEntity]), ConfigModule],
+  controllers: [PaymentController],
+  providers: [PaymentService],
+  exports: [PaymentService],
+})
+export class PaymentModule {}

--- a/backend/src/modules/payment/payment.service.ts
+++ b/backend/src/modules/payment/payment.service.ts
@@ -1,0 +1,424 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import axios from 'axios';
+import { randomBytes } from 'crypto';
+import { DataSource, Repository } from 'typeorm';
+import { PaymentEntity } from './entities/payment.entity';
+import { PaymentStatusEnum } from './enums/payment-status.enum';
+import { InitiatePaymentDto } from './dto/initiate-payment.dto';
+import {
+  SslCallbackPayload,
+  SslCommerzConfig,
+  SslSessionResponse,
+  SslValidationResponse,
+} from './interfaces/sslcommerz.interface';
+
+const SUCCESSFUL_VALIDATION_STATUSES = ['VALID', 'VALIDATED'];
+const HTTP_TIMEOUT_MS = 20000;
+const AMOUNT_TOLERANCE = 0.01;
+
+@Injectable()
+export class PaymentService {
+  private readonly logger = new Logger(PaymentService.name);
+
+  constructor(
+    @InjectRepository(PaymentEntity)
+    private readonly paymentRepo: Repository<PaymentEntity>,
+    private readonly configService: ConfigService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  async initiatePayment(dto: InitiatePaymentDto): Promise<{
+    paymentId: string;
+    orderId: string;
+    transactionId: string;
+    amount: number;
+    currency: string;
+    gatewayPageUrl: string;
+  }> {
+    const config = this.getConfig();
+    const transactionId = this.generateTransactionId();
+
+    const payment = this.paymentRepo.create({
+      orderId: dto.orderId,
+      transactionId,
+      amount: dto.amount,
+      currency: 'BDT',
+      status: PaymentStatusEnum.PENDING,
+      customerName: dto.customer.name,
+      customerEmail: dto.customer.email,
+      customerPhone: dto.customer.phone,
+    });
+    await this.paymentRepo.save(payment);
+
+    this.logger.log(
+      `Initiating payment | paymentId=${payment.id} tran_id=${transactionId} orderId=${dto.orderId} amount=${dto.amount}`,
+    );
+
+    const body = this.buildSessionPayload(config, dto, transactionId);
+
+    let session: SslSessionResponse;
+    try {
+      const response = await axios.post<SslSessionResponse>(config.sessionApi, body.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        timeout: HTTP_TIMEOUT_MS,
+      });
+      session = response.data;
+    } catch (error) {
+      this.logger.error(
+        `SSLCommerz session API call failed | tran_id=${transactionId} error=${this.stringifyError(error)}`,
+      );
+      payment.status = PaymentStatusEnum.FAILED;
+      await this.paymentRepo.save(payment);
+      throw new InternalServerErrorException('Failed to reach payment gateway');
+    }
+
+    payment.gatewayResponse = session as unknown as Record<string, unknown>;
+
+    if (session.status !== 'SUCCESS' || !session.GatewayPageURL) {
+      payment.status = PaymentStatusEnum.FAILED;
+      await this.paymentRepo.save(payment);
+      this.logger.warn(
+        `Gateway session creation rejected | tran_id=${transactionId} reason=${session.failedreason ?? 'unknown'}`,
+      );
+      throw new BadRequestException(session.failedreason || 'Failed to create payment session');
+    }
+
+    await this.paymentRepo.save(payment);
+
+    return {
+      paymentId: payment.id,
+      orderId: payment.orderId,
+      transactionId: payment.transactionId,
+      amount: Number(payment.amount),
+      currency: payment.currency,
+      gatewayPageUrl: session.GatewayPageURL,
+    };
+  }
+
+  /**
+   * Verify and settle a payment using the validation API.
+   * Idempotent: an already-PAID payment is returned without re-processing.
+   */
+  async verifyPayment(params: {
+    transactionId?: string;
+    valId?: string;
+  }): Promise<PaymentEntity> {
+    const transactionId = await this.resolveTransactionId(params);
+    return this.settlePayment(transactionId, params.valId);
+  }
+
+  /**
+   * Server-to-server IPN handler. Verifies via validation API and settles.
+   * Designed to be idempotent so a missed frontend callback is recovered safely.
+   */
+  async handleIpn(payload: SslCallbackPayload): Promise<{ received: boolean; status: PaymentStatusEnum }> {
+    this.logger.log(
+      `IPN received | tran_id=${payload.tran_id ?? 'n/a'} val_id=${payload.val_id ?? 'n/a'} status=${payload.status ?? 'n/a'}`,
+    );
+
+    if (!payload.tran_id) {
+      throw new BadRequestException('tran_id is required');
+    }
+
+    const gatewayStatus = (payload.status ?? '').toUpperCase();
+
+    if (payload.val_id && (gatewayStatus === 'VALID' || gatewayStatus === 'VALIDATED' || gatewayStatus === '')) {
+      const payment = await this.settlePayment(payload.tran_id, payload.val_id, payload);
+      return { received: true, status: payment.status };
+    }
+
+    if (gatewayStatus === 'FAILED') {
+      const payment = await this.markTerminal(payload.tran_id, PaymentStatusEnum.FAILED, payload);
+      return { received: true, status: payment.status };
+    }
+
+    if (gatewayStatus === 'CANCELLED') {
+      const payment = await this.markTerminal(payload.tran_id, PaymentStatusEnum.CANCELLED, payload);
+      return { received: true, status: payment.status };
+    }
+
+    // Unknown / incomplete IPN: acknowledge without changing state.
+    const existing = await this.paymentRepo.findOne({ where: { transactionId: payload.tran_id } });
+    return { received: true, status: existing?.status ?? PaymentStatusEnum.PENDING };
+  }
+
+  async handleSuccessCallback(payload: SslCallbackPayload): Promise<PaymentEntity> {
+    if (!payload.tran_id) {
+      throw new BadRequestException('tran_id is required');
+    }
+    // Never trust the success callback alone; always confirm through validation API.
+    return this.settlePayment(payload.tran_id, payload.val_id, payload);
+  }
+
+  async handleFailCallback(payload: SslCallbackPayload): Promise<PaymentEntity> {
+    if (!payload.tran_id) {
+      throw new BadRequestException('tran_id is required');
+    }
+    return this.markTerminal(payload.tran_id, PaymentStatusEnum.FAILED, payload);
+  }
+
+  async handleCancelCallback(payload: SslCallbackPayload): Promise<PaymentEntity> {
+    if (!payload.tran_id) {
+      throw new BadRequestException('tran_id is required');
+    }
+    return this.markTerminal(payload.tran_id, PaymentStatusEnum.CANCELLED, payload);
+  }
+
+  async getByTransactionId(transactionId: string): Promise<PaymentEntity> {
+    const payment = await this.paymentRepo.findOne({ where: { transactionId } });
+    if (!payment) {
+      throw new NotFoundException('Payment not found');
+    }
+    return payment;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core settlement (locked + idempotent)
+  // ---------------------------------------------------------------------------
+
+  private async settlePayment(
+    transactionId: string,
+    valId: string | undefined,
+    callbackPayload?: SslCallbackPayload,
+  ): Promise<PaymentEntity> {
+    return this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(PaymentEntity);
+      const payment = await repo.findOne({
+        where: { transactionId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!payment) {
+        throw new NotFoundException('Payment not found');
+      }
+
+      // Idempotency: once paid, do not re-process or downgrade.
+      if (payment.status === PaymentStatusEnum.PAID) {
+        this.logger.log(`Payment already settled | tran_id=${transactionId} (idempotent no-op)`);
+        return payment;
+      }
+
+      const effectiveValId = valId ?? payment.sslValId ?? undefined;
+      if (!effectiveValId) {
+        throw new BadRequestException('val_id is required to verify this payment');
+      }
+
+      const validation = await this.validateWithGateway(effectiveValId);
+      const validationStatus = (validation.status ?? '').toUpperCase();
+
+      if (callbackPayload) {
+        payment.gatewayResponse = {
+          ...(payment.gatewayResponse ?? {}),
+          last_callback: callbackPayload,
+        };
+      }
+      payment.validationResponse = validation as unknown as Record<string, unknown>;
+      payment.sslValId = effectiveValId;
+
+      if (!SUCCESSFUL_VALIDATION_STATUSES.includes(validationStatus)) {
+        await repo.save(payment);
+        this.logger.warn(
+          `Validation unsuccessful | tran_id=${transactionId} status=${validationStatus || 'unknown'}`,
+        );
+        throw new BadRequestException('Payment validation was not successful');
+      }
+
+      // Guard against tampering: validated amount must match the recorded amount.
+      const validatedAmount = Number(validation.amount);
+      const expectedAmount = Number(payment.amount);
+      if (
+        !Number.isNaN(validatedAmount) &&
+        Math.abs(validatedAmount - expectedAmount) > AMOUNT_TOLERANCE
+      ) {
+        await repo.save(payment);
+        this.logger.error(
+          `Amount mismatch | tran_id=${transactionId} expected=${expectedAmount} validated=${validatedAmount}`,
+        );
+        throw new BadRequestException('Payment amount mismatch');
+      }
+
+      // Guard against transaction id mismatch from the gateway response.
+      if (validation.tran_id && validation.tran_id !== transactionId) {
+        await repo.save(payment);
+        this.logger.error(
+          `Transaction id mismatch | expected=${transactionId} validated=${validation.tran_id}`,
+        );
+        throw new BadRequestException('Transaction id mismatch');
+      }
+
+      payment.status = PaymentStatusEnum.PAID;
+      payment.paymentMethod = validation.card_type ?? payment.paymentMethod ?? null;
+      await repo.save(payment);
+
+      this.logger.log(`Payment settled successfully | tran_id=${transactionId} status=PAID`);
+      return payment;
+    });
+  }
+
+  /**
+   * Mark a payment FAILED/CANCELLED. Idempotent and never overrides a PAID payment.
+   */
+  private async markTerminal(
+    transactionId: string,
+    status: PaymentStatusEnum.FAILED | PaymentStatusEnum.CANCELLED,
+    callbackPayload?: SslCallbackPayload,
+  ): Promise<PaymentEntity> {
+    return this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(PaymentEntity);
+      const payment = await repo.findOne({
+        where: { transactionId },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!payment) {
+        throw new NotFoundException('Payment not found');
+      }
+
+      if (callbackPayload) {
+        payment.gatewayResponse = {
+          ...(payment.gatewayResponse ?? {}),
+          last_callback: callbackPayload,
+        };
+      }
+
+      // Do not override a completed payment.
+      if (payment.status === PaymentStatusEnum.PAID) {
+        await repo.save(payment);
+        this.logger.warn(
+          `Ignoring ${status} callback for already PAID payment | tran_id=${transactionId}`,
+        );
+        return payment;
+      }
+
+      if (payment.status === PaymentStatusEnum.PENDING) {
+        payment.status = status;
+      }
+
+      await repo.save(payment);
+      this.logger.log(`Payment marked ${payment.status} | tran_id=${transactionId}`);
+      return payment;
+    });
+  }
+
+  private async validateWithGateway(valId: string): Promise<SslValidationResponse> {
+    const config = this.getConfig();
+    const params = new URLSearchParams({
+      val_id: valId,
+      store_id: config.storeId,
+      store_passwd: config.storePassword,
+      format: 'json',
+      v: '1',
+    });
+
+    try {
+      const response = await axios.get<SslValidationResponse>(
+        `${config.validationApi}?${params.toString()}`,
+        { timeout: HTTP_TIMEOUT_MS },
+      );
+      return response.data;
+    } catch (error) {
+      this.logger.error(
+        `SSLCommerz validation API call failed | val_id=${valId} error=${this.stringifyError(error)}`,
+      );
+      throw new InternalServerErrorException('Failed to reach payment validation service');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private async resolveTransactionId(params: {
+    transactionId?: string;
+    valId?: string;
+  }): Promise<string> {
+    if (params.transactionId) {
+      return params.transactionId;
+    }
+
+    if (!params.valId) {
+      throw new BadRequestException('Either transactionId or val_id is required');
+    }
+
+    // Resolve tran_id from the validation API when only val_id is supplied.
+    const validation = await this.validateWithGateway(params.valId);
+    if (!validation.tran_id) {
+      throw new BadRequestException('Unable to resolve transaction from val_id');
+    }
+    return validation.tran_id;
+  }
+
+  private buildSessionPayload(
+    config: SslCommerzConfig,
+    dto: InitiatePaymentDto,
+    transactionId: string,
+  ): URLSearchParams {
+    const payload = new URLSearchParams();
+    payload.append('store_id', config.storeId);
+    payload.append('store_passwd', config.storePassword);
+    payload.append('total_amount', Number(dto.amount).toFixed(2));
+    payload.append('currency', 'BDT');
+    payload.append('tran_id', transactionId);
+    payload.append('success_url', `${config.frontendBaseUrl}/payment/success`);
+    payload.append('fail_url', `${config.frontendBaseUrl}/payment/fail`);
+    payload.append('cancel_url', `${config.frontendBaseUrl}/payment/cancel`);
+    payload.append('ipn_url', `${config.backendBaseUrl}/api/v1/payments/ipn`);
+    payload.append('cus_name', dto.customer.name);
+    payload.append('cus_email', dto.customer.email);
+    payload.append('cus_phone', dto.customer.phone);
+    payload.append('product_name', dto.productName ?? 'TestTaker Order');
+    payload.append('product_category', dto.productCategory ?? 'general');
+    payload.append('product_profile', 'general');
+    return payload;
+  }
+
+  private generateTransactionId(): string {
+    const time = Date.now().toString(36);
+    const random = randomBytes(4).toString('hex');
+    return `TT_${time}_${random}`.toUpperCase();
+  }
+
+  private getConfig(): SslCommerzConfig {
+    const config: SslCommerzConfig = {
+      storeId: this.configService.get<string>('SSL_STORE_ID', ''),
+      storePassword: this.configService.get<string>('SSL_STORE_PASSWORD', ''),
+      sessionApi: this.configService.get<string>('SSL_SESSION_API', ''),
+      validationApi: this.configService.get<string>('SSL_VALIDATION_API', ''),
+      backendBaseUrl: this.configService.get<string>('BACKEND_BASE_URL', ''),
+      frontendBaseUrl: this.configService.get<string>('FRONTEND_BASE_URL', ''),
+    };
+
+    const missing = Object.entries(config)
+      .filter(([, value]) => !value)
+      .map(([key]) => key);
+
+    if (missing.length > 0) {
+      this.logger.error(`Missing SSLCommerz configuration: ${missing.join(', ')}`);
+      throw new InternalServerErrorException('Payment gateway is not configured');
+    }
+
+    return config;
+  }
+
+  private stringifyError(error: unknown): string {
+    if (axios.isAxiosError(error)) {
+      return `${error.code ?? ''} ${error.message}`.trim();
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+}


### PR DESCRIPTION
Add a dedicated payment module (initiate, verify, ipn, success/fail/cancel) using the SSLCommerz session and validation APIs. Verification is idempotent and row-locked, results are validated server-side before marking PAID, and all credentials/URLs are read from environment variables.