### PR TITLE
fix(payments): settle SSLCommerz callbacks server-side

### DIFF
--- a/backend/src/common/interceptors/wrap-response.interceptor.ts
+++ b/backend/src/common/interceptors/wrap-response.interceptor.ts
@@ -21,13 +21,21 @@ export class WrapResponseInterceptor<T>
 {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     return next.handle().pipe(
-      map((data) => ({
-        statusCode: context.switchToHttp().getResponse().statusCode,
-        message: data.message ?? 'successfull',
-        payload: data.payload,
-        meta: data.meta ?? undefined,
-        error: false,
-      })),
+      map((data) => {
+        const response = context.switchToHttp().getResponse();
+        // Handlers that manage the response themselves (e.g. @Res() redirects)
+        // emit no data and have already sent headers; leave them untouched.
+        if (response.headersSent || data === undefined || data === null) {
+          return data;
+        }
+        return {
+          statusCode: response.statusCode,
+          message: data.message ?? 'successfull',
+          payload: data.payload,
+          meta: data.meta ?? undefined,
+          error: false,
+        };
+      }),
     );
   }
 }

--- a/backend/src/modules/payment/payment.controller.ts
+++ b/backend/src/modules/payment/payment.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import type { Request } from 'express';
+import { Body, Controller, Get, Logger, Param, Post, Req, Res } from '@nestjs/common';
+import { ApiExcludeEndpoint, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
 import { PaymentService } from './payment.service';
 import { InitiatePaymentDto } from './dto/initiate-payment.dto';
 import { VerifyPaymentDto } from './dto/verify-payment.dto';
@@ -10,6 +10,8 @@ import { SslCallbackPayload } from './interfaces/sslcommerz.interface';
 @ApiTags('Payments')
 @Controller({ path: 'payments', version: '1' })
 export class PaymentController {
+  private readonly logger = new Logger(PaymentController.name);
+
   constructor(private readonly paymentService: PaymentService) {}
 
   @Post('initiate')
@@ -53,34 +55,57 @@ export class PaymentController {
   }
 
   @Post('success')
-  @ApiOperation({
-    summary: 'Gateway success callback',
-    description:
-      'Optional server-side success handler. Always re-validates through the validation API before marking PAID.',
-  })
-  @ApiResponse({ status: 201, description: 'Success callback processed' })
-  async success(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+  @ApiExcludeEndpoint()
+  async success(@Body() dto: SslCommerzCallbackDto, @Req() req: Request, @Res() res: Response) {
     const payload = this.mergeCallback(dto, req);
-    const payment = await this.paymentService.handleSuccessCallback(payload);
-    return { message: 'Payment success processed', payload: payment };
+    const frontend = this.paymentService.getFrontendBaseUrl();
+    const tranId = encodeURIComponent(payload.tran_id ?? '');
+
+    try {
+      const payment = await this.paymentService.handleSuccessCallback(payload);
+      this.logger.log(`Success callback settled | tran_id=${payment.transactionId} status=${payment.status}`);
+      return res.redirect(`${frontend}/payment/success?tran_id=${encodeURIComponent(payment.transactionId)}`);
+    } catch (error) {
+      // Validation failed (or amount/tran mismatch): never show a success page.
+      this.logger.warn(
+        `Success callback rejected | tran_id=${payload.tran_id ?? 'n/a'} error=${error instanceof Error ? error.message : String(error)}`,
+      );
+      return res.redirect(`${frontend}/payment/fail?tran_id=${tranId}`);
+    }
   }
 
   @Post('fail')
-  @ApiOperation({ summary: 'Gateway fail callback' })
-  @ApiResponse({ status: 201, description: 'Fail callback processed' })
-  async fail(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+  @ApiExcludeEndpoint()
+  async fail(@Body() dto: SslCommerzCallbackDto, @Req() req: Request, @Res() res: Response) {
     const payload = this.mergeCallback(dto, req);
-    const payment = await this.paymentService.handleFailCallback(payload);
-    return { message: 'Payment failure processed', payload: payment };
+    const frontend = this.paymentService.getFrontendBaseUrl();
+    const tranId = encodeURIComponent(payload.tran_id ?? '');
+
+    try {
+      await this.paymentService.handleFailCallback(payload);
+    } catch (error) {
+      this.logger.warn(
+        `Fail callback could not update payment | tran_id=${payload.tran_id ?? 'n/a'} error=${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return res.redirect(`${frontend}/payment/fail?tran_id=${tranId}`);
   }
 
   @Post('cancel')
-  @ApiOperation({ summary: 'Gateway cancel callback' })
-  @ApiResponse({ status: 201, description: 'Cancel callback processed' })
-  async cancel(@Body() dto: SslCommerzCallbackDto, @Req() req: Request) {
+  @ApiExcludeEndpoint()
+  async cancel(@Body() dto: SslCommerzCallbackDto, @Req() req: Request, @Res() res: Response) {
     const payload = this.mergeCallback(dto, req);
-    const payment = await this.paymentService.handleCancelCallback(payload);
-    return { message: 'Payment cancellation processed', payload: payment };
+    const frontend = this.paymentService.getFrontendBaseUrl();
+    const tranId = encodeURIComponent(payload.tran_id ?? '');
+
+    try {
+      await this.paymentService.handleCancelCallback(payload);
+    } catch (error) {
+      this.logger.warn(
+        `Cancel callback could not update payment | tran_id=${payload.tran_id ?? 'n/a'} error=${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return res.redirect(`${frontend}/payment/cancel?tran_id=${tranId}`);
   }
 
   @Get(':transactionId')

--- a/backend/src/modules/payment/payment.service.ts
+++ b/backend/src/modules/payment/payment.service.ts
@@ -187,6 +187,11 @@ export class PaymentService {
     return this.markTerminal(payload.tran_id, PaymentStatusEnum.CANCELLED, payload);
   }
 
+  /** Frontend origin used to redirect the browser after a gateway callback. */
+  getFrontendBaseUrl(): string {
+    return this.configService.get<string>('FRONTEND_BASE_URL', '');
+  }
+
   async getByTransactionId(transactionId: string): Promise<PaymentEntity> {
     const payment = await this.paymentRepo.findOne({ where: { transactionId } });
     if (!payment) {
@@ -384,9 +389,11 @@ export class PaymentService {
     payload.append('total_amount', Number(dto.amount).toFixed(2));
     payload.append('currency', 'BDT');
     payload.append('tran_id', transactionId);
-    payload.append('success_url', `${config.frontendBaseUrl}/payment/success`);
-    payload.append('fail_url', `${config.frontendBaseUrl}/payment/fail`);
-    payload.append('cancel_url', `${config.frontendBaseUrl}/payment/cancel`);
+    // Settlement happens server-side: the gateway returns to the backend, which
+    // validates, updates the DB, then redirects the browser to the frontend.
+    payload.append('success_url', `${config.backendBaseUrl}/api/v1/payments/success`);
+    payload.append('fail_url', `${config.backendBaseUrl}/api/v1/payments/fail`);
+    payload.append('cancel_url', `${config.backendBaseUrl}/api/v1/payments/cancel`);
     payload.append('ipn_url', `${config.backendBaseUrl}/api/v1/payments/ipn`);
 
     // EMI (mandatory)

--- a/frontend/app/payment/cancel/page.tsx
+++ b/frontend/app/payment/cancel/page.tsx
@@ -1,11 +1,22 @@
 import Link from "next/link";
 
-export default function PaymentCancelPage() {
+export default async function PaymentCancelPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tran_id?: string }>;
+}) {
+  const { tran_id } = await searchParams;
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-[#EFF0F3] px-6">
       <div className="max-w-md w-full bg-white rounded-[12px] p-8 text-center">
         <h1 className="text-2xl font-semibold text-[#232A25] mb-2">Payment cancelled</h1>
-        <p className="text-[#747775] mb-6">You cancelled the payment. No charges were made.</p>
+        <p className="text-[#747775] mb-2">You cancelled the payment. No charges were made.</p>
+        {tran_id && (
+          <p className="text-xs text-[#9AA09B] mb-6">
+            Reference: <span className="font-mono">{tran_id}</span>
+          </p>
+        )}
         <Link href="/account" className="inline-block px-6 py-2.5 rounded-[8px] bg-[#49734F] text-white">
           Back to billing
         </Link>

--- a/frontend/app/payment/fail/page.tsx
+++ b/frontend/app/payment/fail/page.tsx
@@ -1,11 +1,22 @@
 import Link from "next/link";
 
-export default function PaymentFailPage() {
+export default async function PaymentFailPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tran_id?: string }>;
+}) {
+  const { tran_id } = await searchParams;
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-[#EFF0F3] px-6">
       <div className="max-w-md w-full bg-white rounded-[12px] p-8 text-center">
         <h1 className="text-2xl font-semibold text-[#232A25] mb-2">Payment failed</h1>
-        <p className="text-[#747775] mb-6">Your payment could not be completed. Please try again.</p>
+        <p className="text-[#747775] mb-2">Your payment could not be completed. Please try again.</p>
+        {tran_id && (
+          <p className="text-xs text-[#9AA09B] mb-6">
+            Reference: <span className="font-mono">{tran_id}</span>
+          </p>
+        )}
         <Link href="/account" className="inline-block px-6 py-2.5 rounded-[8px] bg-[#49734F] text-white">
           Back to billing
         </Link>

--- a/frontend/component/Payment/PaymentSuccessContent.tsx
+++ b/frontend/component/Payment/PaymentSuccessContent.tsx
@@ -1,47 +1,142 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import axiosReq from "@/lib/axios";
 
+type PaymentStatus = "PENDING" | "PAID" | "FAILED" | "CANCELLED";
+
+type PaymentView = {
+  transactionId: string;
+  status: PaymentStatus;
+  amount: number;
+  currency: string;
+  paymentMethod: string | null;
+  subscriptionId?: string;
+};
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLLS = 8;
+
 export default function PaymentSuccessContent() {
   const searchParams = useSearchParams();
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
-  const [message, setMessage] = useState("Verifying your payment...");
+  const [phase, setPhase] = useState<"loading" | "settled" | "pending" | "error">("loading");
+  const [payment, setPayment] = useState<PaymentView | null>(null);
+  const [message, setMessage] = useState("Confirming your payment...");
+
+  const fetchPayment = useCallback(
+    async (tranId: string): Promise<PaymentView | null> => {
+      const res = await axiosReq.get(`${baseUrl}/payments/${encodeURIComponent(tranId)}`);
+      return (res.data?.payload as PaymentView) ?? null;
+    },
+    [baseUrl],
+  );
 
   useEffect(() => {
-    const verify = async () => {
-      const tranId = searchParams.get("tran_id");
-      const valId = searchParams.get("val_id");
+    const tranId = searchParams.get("tran_id");
 
-      if (!tranId) {
-        setStatus("error");
-        setMessage("Missing transaction reference.");
-        return;
-      }
+    if (!tranId) {
+      setPhase("error");
+      setMessage("Missing transaction reference.");
+      return;
+    }
 
+    let cancelled = false;
+    let attempts = 0;
+
+    const poll = async () => {
+      attempts += 1;
       try {
-        await axiosReq.post(`${baseUrl}/payments/verify`, { transactionId: tranId, valId });
-        setStatus("success");
-        setMessage("Payment successful! Your subscription is now active.");
+        const result = await fetchPayment(tranId);
+        if (cancelled) return;
+
+        if (result) {
+          setPayment(result);
+
+          if (result.status === "PAID") {
+            setPhase("settled");
+            setMessage("Payment successful! Your subscription is now active.");
+            return;
+          }
+
+          if (result.status === "FAILED" || result.status === "CANCELLED") {
+            setPhase("error");
+            setMessage(
+              result.status === "CANCELLED"
+                ? "This payment was cancelled."
+                : "This payment did not go through.",
+            );
+            return;
+          }
+        }
+
+        if (attempts >= MAX_POLLS) {
+          setPhase("pending");
+          setMessage("Payment is still being confirmed. This can take a moment.");
+          return;
+        }
+
+        setTimeout(() => void poll(), POLL_INTERVAL_MS);
       } catch {
-        setStatus("error");
-        setMessage("Payment verification failed. Contact support if you were charged.");
+        if (cancelled) return;
+        if (attempts >= MAX_POLLS) {
+          setPhase("error");
+          setMessage("We couldn't confirm your payment. Contact support if you were charged.");
+          return;
+        }
+        setTimeout(() => void poll(), POLL_INTERVAL_MS);
       }
     };
 
-    void verify();
-  }, [baseUrl, searchParams]);
+    void poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchPayment, searchParams]);
+
+  const heading =
+    phase === "settled"
+      ? "Payment successful"
+      : phase === "error"
+        ? "Payment issue"
+        : phase === "pending"
+          ? "Payment processing"
+          : "Processing...";
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-[#EFF0F3] px-6">
       <div className="max-w-md w-full bg-white rounded-[12px] p-8 text-center">
-        <h1 className="text-2xl font-semibold text-[#232A25] mb-2">
-          {status === "loading" ? "Processing..." : status === "success" ? "Payment successful" : "Payment issue"}
-        </h1>
+        <h1 className="text-2xl font-semibold text-[#232A25] mb-2">{heading}</h1>
         <p className="text-[#747775] mb-6">{message}</p>
+
+        {payment && (
+          <dl className="text-left text-sm bg-[#F7F8F9] rounded-[8px] p-4 mb-6 space-y-2">
+            <div className="flex justify-between">
+              <dt className="text-[#747775]">Status</dt>
+              <dd className="font-medium text-[#232A25]">{payment.status}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-[#747775]">Amount</dt>
+              <dd className="font-medium text-[#232A25]">
+                {payment.currency} {Number(payment.amount).toFixed(2)}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-[#747775]">Payment method</dt>
+              <dd className="font-medium text-[#232A25]">{payment.paymentMethod ?? "—"}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-[#747775]">Subscription</dt>
+              <dd className="font-medium text-[#232A25]">
+                {payment.status === "PAID" ? "Activated" : "Pending"}
+              </dd>
+            </div>
+          </dl>
+        )}
+
         <Link href="/account" className="inline-block px-6 py-2.5 rounded-[8px] bg-[#49734F] text-white">
           Go to account
         </Link>

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -63,10 +63,12 @@ const routePolicies: RoutePolicy[] = [
     redirectUnauthorizedTo: "/login",
   },
   {
+    // Gateway return pages. SSLCommerz redirects here from its own domain, so
+    // these must never require authentication (the auth cookie is SameSite=Lax
+    // and is not sent on the cross-site navigation).
     path: "/payment",
     match: "prefix",
-    allowedRoles: ["TEACHER"],
-    redirectUnauthorizedTo: "/login",
+    isPublic: true,
   },
   {
     path: "/tests",


### PR DESCRIPTION
Move payment settlement to the backend so the gateway returns to backend endpoints which validate, update the DB, then redirect the browser to the frontend result pages. Fixes the cross-site POST + SameSite=Lax cookie issue that redirected users to /login after paying.

- session success/fail/cancel URLs now point to backend /api/v1/payments/*
- success/fail/cancel handlers redirect the browser to the frontend with tran_id
- guard global response interceptor against @Res() redirect handlers
- make /payment/* result pages public in the frontend middleware
- success page polls GET /payments/:id and shows status/amount/method/subscription
- fail/cancel pages read tran_id from query params