### PR TITLE
feat(exams): add exam details page with edit and enable/disable

### DIFF
--- a/backend/src/exams/dto/update-exam.dto.ts
+++ b/backend/src/exams/dto/update-exam.dto.ts
@@ -1,8 +1,17 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
-import { IsArray, IsUUID } from 'class-validator';
+import { IsArray, IsBoolean, IsUUID } from 'class-validator';
 import { CreateExamQuestionDto } from './create-exam-question.dto';
 
 export class UpdateExamQuestionDto extends PartialType(CreateExamQuestionDto) {}
+
+export class SetExamStatusDto {
+  @ApiProperty({
+    description: 'Whether the exam is active (visible to students). Set false to disable.',
+    example: true,
+  })
+  @IsBoolean()
+  active: boolean;
+}
 
 export class UpdateExcludedStudentsDto {
   @ApiProperty({

--- a/backend/src/exams/exam.controller.ts
+++ b/backend/src/exams/exam.controller.ts
@@ -7,10 +7,11 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Put,
   UseGuards,
 } from "@nestjs/common";
 import { CreateObjectiveExamDto, CreateSubjectiveExamDto } from "./dto/create-exam.dto";
-import { UpdateExcludedStudentsDto } from "./dto/update-exam.dto";
+import { SetExamStatusDto, UpdateExcludedStudentsDto } from "./dto/update-exam.dto";
 import {
   ApiBearerAuth,
   ApiBody,
@@ -176,6 +177,55 @@ export class ExamController {
     }
     const payload = await this.examService.findOne(id, jwtPayload);
     return { message: "Exam details retrieved successfully", payload };
+  }
+
+  @Put(":id")
+  @ApiBearerAuth("jwt")
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles(RolesEnum.TEACHER, RolesEnum.ADMIN, RolesEnum.SUPER_ADMIN)
+  @ApiOperation({
+    summary: "Update an exam (unified wizard)",
+    description:
+      "Replace an exam's details and questions. Only the owner (or admin) may update, and only before the exam start time.",
+  })
+  @ApiBody({ type: CreateExamWizardDto })
+  @ApiParam({ name: "id", description: "Exam UUID" })
+  @ApiResponse({ status: 200, description: "Exam updated successfully" })
+  @ApiResponse({ status: 400, description: "Validation error" })
+  @ApiResponse({ status: 403, description: "Cannot edit after the exam has started" })
+  @ApiResponse({ status: 404, description: "Exam not found" })
+  async updateExam(
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: CreateExamWizardDto,
+    @UserPayload() jwtPayload: JwtPayloadInterface,
+  ) {
+    const payload = await this.examService.updateFromWizard(id, dto, jwtPayload);
+    return { message: "Exam updated successfully", payload };
+  }
+
+  @Patch(":id/status")
+  @ApiBearerAuth("jwt")
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles(RolesEnum.TEACHER, RolesEnum.ADMIN, RolesEnum.SUPER_ADMIN)
+  @ApiOperation({
+    summary: "Enable or disable an exam",
+    description:
+      "Disable an exam to hide it from students and block participation. Only the owner (or admin) may toggle, and only before the exam start time.",
+  })
+  @ApiParam({ name: "id", description: "Exam UUID" })
+  @ApiResponse({ status: 200, description: "Exam status updated" })
+  @ApiResponse({ status: 403, description: "Cannot change status after the exam has started" })
+  @ApiResponse({ status: 404, description: "Exam not found" })
+  async setStatus(
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() dto: SetExamStatusDto,
+    @UserPayload() jwtPayload: JwtPayloadInterface,
+  ) {
+    const payload = await this.examService.setExamActive(id, dto.active, jwtPayload);
+    return {
+      message: dto.active ? "Exam enabled successfully" : "Exam disabled successfully",
+      payload,
+    };
   }
 
   @Patch(":id/excluded-students")

--- a/backend/src/exams/exam.service.ts
+++ b/backend/src/exams/exam.service.ts
@@ -5,7 +5,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, DeepPartial, Repository, In } from 'typeorm';
+import { DataSource, DeepPartial, EntityManager, Repository, In } from 'typeorm';
 import { buildResponseOptionId } from './utils/exam-option-ids.util';
 import { ExamEntity, ExamTypeEnum } from './entities/exam.entity';
 import {
@@ -28,6 +28,7 @@ import { UserEntity } from 'src/user/entities/user.entity';
 import { ClassEntity } from 'src/classes/entities/class.entity';
 import { ClassStudentEntity, ClassStudentStatusEnum } from 'src/classes/entities/class-student.entity';
 import { RolesEnum } from 'src/common/enums/roles.enum';
+import { ActiveStatusEnum } from 'src/common/enums/active-status.enum';
 import { SmsService } from 'src/sms/sms.service';
 import { SubjectService } from 'src/subjects/subject.service';
 import { EntitlementsService } from 'src/subscriptions/entitlements.service';
@@ -892,6 +893,10 @@ export class ExamService {
     studentId: string,
     jwtPayload: JwtPayloadInterface,
   ): Promise<void> {
+    if (exam.is_active !== ActiveStatusEnum.ACTIVE) {
+      throw new ForbiddenException('This exam is not available');
+    }
+
     const excluded = exam.excluded_students?.some((s) => s.id === studentId);
     if (excluded) {
       throw new ForbiddenException('You have been excluded from this exam');
@@ -1025,6 +1030,7 @@ export class ExamService {
         .leftJoinAndSelect('questionSections.subject', 'sectionSubject')
         .leftJoin('exam.excluded_students', 'excluded')
         .where('exam.class_id IN (:...classIds)', { classIds })
+        .andWhere('exam.is_active = :active', { active: ActiveStatusEnum.ACTIVE })
         .andWhere('(excluded.id IS NULL OR excluded.id != :studentId)', { studentId })
         .orderBy('exam.exam_start_time', 'DESC')
         .getMany();
@@ -1039,6 +1045,7 @@ export class ExamService {
         .leftJoinAndSelect('exam.primary_subject', 'primary_subject')
         .leftJoinAndSelect('exam.questionSections', 'questionSections')
         .leftJoinAndSelect('questionSections.subject', 'sectionSubject')
+        .where('exam.is_active = :active', { active: ActiveStatusEnum.ACTIVE })
         .orderBy('exam.exam_start_time', 'DESC');
       const targetExams = await targetQuery.getMany();
       targetExams.forEach((e) => byId.set(e.id, e));
@@ -1304,6 +1311,7 @@ export class ExamService {
       id: exam.id,
       test_name: exam.test_name,
       status: this.computeExamLifecycleStatus(exam.exam_start_time, exam.exam_end_time),
+      is_active: exam.is_active,
       formState: {
         testName: exam.test_name ?? '',
         duration: exam.duration_minutes ?? 0,
@@ -1584,6 +1592,337 @@ export class ExamService {
     }
 
     return CORRECT_ANSWER_ENUM_BY_OPTION_INDEX.indexOf(answer);
+  }
+
+  /**
+   * Editing/disabling is only allowed while the exam has not started yet.
+   */
+  private assertExamEditableBeforeStart(exam: ExamEntity): void {
+    if (Date.now() >= new Date(exam.exam_start_time).getTime()) {
+      throw new ForbiddenException(
+        'This exam has already started; it can no longer be edited or disabled.',
+      );
+    }
+  }
+
+  /**
+   * Enable/disable an exam. Disabled exams are hidden from students and cannot be taken.
+   * Owner (or admin) only, and only before the exam start time.
+   */
+  async setExamActive(
+    id: string,
+    active: boolean,
+    jwtPayload: JwtPayloadInterface,
+  ): Promise<any> {
+    const exam = await this.findOneEntity(id);
+
+    if (
+      jwtPayload.role === RolesEnum.TEACHER &&
+      exam.created_by !== jwtPayload.id
+    ) {
+      throw new ForbiddenException('You do not have permission to update this exam');
+    }
+
+    this.assertExamEditableBeforeStart(exam);
+
+    exam.is_active = active ? ActiveStatusEnum.ACTIVE : ActiveStatusEnum.INACTIVE;
+    exam.updated_by = jwtPayload.id;
+    exam.updated_user_name = jwtPayload.full_name;
+    exam.updated_at = new Date();
+    await this.examRepo.save(exam);
+
+    return this.formatExamResponse(exam, { includeCorrectAnswers: true });
+  }
+
+  /**
+   * Replace an exam's details and questions via the wizard payload.
+   * Owner (or admin) only, and only before the exam start time.
+   */
+  async updateFromWizard(
+    id: string,
+    dto: CreateExamWizardDto,
+    jwtPayload: JwtPayloadInterface,
+  ): Promise<any> {
+    const { formState, subjects, publishState } = dto;
+
+    const existing = await this.findOneEntity(id);
+
+    if (
+      jwtPayload.role === RolesEnum.TEACHER &&
+      existing.created_by !== jwtPayload.id
+    ) {
+      throw new ForbiddenException('You do not have permission to edit this exam');
+    }
+
+    this.assertExamEditableBeforeStart(existing);
+
+    for (const subj of subjects) {
+      for (const raw of subj.questions) {
+        const parsed = parseWizardQuestion(raw);
+        if (parsed.kind === 'ungraded') {
+          await this.entitlementsService.assertFeature(
+            jwtPayload.id,
+            FeatureKey.ALLOW_UNGRADED_QUESTIONS,
+            'Ungraded questions are not available on your plan. Please upgrade.',
+          );
+        }
+        if (parsed.kind === 'passage') {
+          await this.entitlementsService.assertFeature(
+            jwtPayload.id,
+            FeatureKey.ALLOW_PASSAGE_QUESTIONS,
+            'Passage questions are not available on your plan. Please upgrade.',
+          );
+        }
+        const questionImage = (raw as { image?: unknown }).image;
+        if (questionImage) {
+          await this.entitlementsService.assertFeature(
+            jwtPayload.id,
+            FeatureKey.ALLOW_QUESTION_IMAGES,
+            'Question images are not available on your plan. Please upgrade.',
+          );
+        }
+      }
+    }
+
+    if (publishState.scheduleAt >= publishState.endingAt) {
+      throw new BadRequestException('Start time must be before end time');
+    }
+
+    if (formState.allowNegativeMarking) {
+      const v = Number(formState.negativeMarking);
+      if (
+        formState.negativeMarking === undefined ||
+        formState.negativeMarking === null ||
+        Number.isNaN(v) ||
+        v <= 0 ||
+        v > 100
+      ) {
+        throw new BadRequestException(
+          'Negative marking must be a percentage between 1 and 100 when enabled',
+        );
+      }
+    }
+
+    const subjectIds = subjects.map((s) => s.id);
+    await this.subjectService.assertSubjectsExist(subjectIds);
+
+    for (const subj of subjects) {
+      validateSubjectQuestions(subj.questions);
+    }
+
+    const { hasAutoScored, hasManual } = this.countQuestionCategories(subjects);
+    if (!hasAutoScored && !hasManual) {
+      throw new BadRequestException('Exam must include at least one question');
+    }
+
+    const primarySubjectId = subjects.length === 1 ? subjects[0].id : null;
+
+    if (publishState.testAudience === TestAudienceEnum.SELECTED_CLASS) {
+      if (!publishState.selectedClassId) {
+        throw new BadRequestException('selectedClassId is required when test audience is selected_class');
+      }
+      const cls = await this.classRepo.findOne({ where: { id: publishState.selectedClassId } });
+      if (!cls) throw new BadRequestException('Class not found');
+      if (
+        jwtPayload.role === RolesEnum.TEACHER &&
+        cls.teacher_id !== jwtPayload.id
+      ) {
+        throw new ForbiddenException('You do not own this class');
+      }
+    }
+
+    let targetStudents: UserEntity[] = [];
+    if (publishState.testAudience === TestAudienceEnum.SPECIFIC_STUDENTS) {
+      const ids = publishState.specificStudents || [];
+      if (ids.length === 0) {
+        throw new BadRequestException('specificStudents must contain at least one student id');
+      }
+      targetStudents = await this.userRepo.find({
+        where: { id: In(ids), role: RolesEnum.STUDENT },
+      });
+      if (targetStudents.length !== ids.length) {
+        throw new BadRequestException('One or more student ids are invalid');
+      }
+    }
+
+    let excludedStudents: UserEntity[] = [];
+    const excludedIds = publishState.excluded_students ?? [];
+    if (excludedIds.length > 0) {
+      excludedStudents = await this.userRepo.find({
+        where: { id: In(excludedIds), role: RolesEnum.STUDENT },
+      });
+      if (excludedStudents.length !== excludedIds.length) {
+        throw new BadRequestException('One or more excluded student ids are invalid');
+      }
+    }
+
+    let studentCount = 0;
+    if (publishState.testAudience === TestAudienceEnum.SPECIFIC_STUDENTS) {
+      studentCount = targetStudents.length;
+    } else if (publishState.testAudience === TestAudienceEnum.SELECTED_CLASS && publishState.selectedClassId) {
+      const approvedCount = await this.classStudentRepo.count({
+        where: {
+          class_id: publishState.selectedClassId,
+          status: ClassStudentStatusEnum.JOINED,
+        },
+      });
+      studentCount = Math.max(0, approvedCount - excludedStudents.length);
+    }
+
+    if (studentCount > 0) {
+      const entitlements = await this.entitlementsService.getEntitlements(jwtPayload.id);
+      const maxStudents = entitlements.limits[LimitKey.MAX_STUDENTS_PER_EXAM] ?? 0;
+      if (maxStudents > 0 && studentCount > maxStudents) {
+        throw new ForbiddenException(
+          `This exam targets ${studentCount} students, which exceeds your plan limit of ${maxStudents}. Please upgrade.`,
+        );
+      }
+    }
+
+    const examType =
+      hasAutoScored && !hasManual
+        ? ExamTypeEnum.OBJECTIVE
+        : hasManual && !hasAutoScored
+          ? ExamTypeEnum.SUBJECTIVE
+          : ExamTypeEnum.OBJECTIVE;
+
+    const negativeVal = formState.allowNegativeMarking
+      ? Number(formState.negativeMarking)
+      : undefined;
+
+    let examSubjectLabel = formState.testName.trim();
+    if (primarySubjectId) {
+      try {
+        const sub = await this.subjectService.findOne(primarySubjectId);
+        examSubjectLabel = sub.name;
+      } catch {
+        // Subject missing despite assertSubjectsExist — keep test title
+      }
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      const examRepo = manager.getRepository(ExamEntity);
+      const questionRepo = manager.getRepository(ExamQuestionEntity);
+      const sectionRepo = manager.getRepository(ExamQuestionSectionEntity);
+
+      // No submissions exist before the start time, so replacing questions is safe.
+      await questionRepo.createQueryBuilder().delete().where('exam_id = :id', { id }).execute();
+      await sectionRepo.createQueryBuilder().delete().where('exam_id = :id', { id }).execute();
+
+      const examRow = await examRepo.findOne({
+        where: { id },
+        relations: ['excluded_students', 'target_students'],
+      });
+      if (!examRow) throw new NotFoundException('Exam not found');
+
+      examRow.exam_type = examType;
+      examRow.exam_kind = null;
+      examRow.test_name = formState.testName.trim();
+      examRow.primary_subject_id = primarySubjectId;
+      examRow.duration_minutes = formState.duration;
+      examRow.passing_score = formState.passingScore ?? null;
+      examRow.publish_timing = publishState.publishTiming;
+      examRow.test_audience = publishState.testAudience;
+      examRow.exam_start_time = publishState.scheduleAt;
+      examRow.exam_end_time = publishState.endingAt;
+      examRow.is_negative_marking = formState.allowNegativeMarking;
+      examRow.negative_mark_value = negativeVal ?? null;
+      examRow.subject = examSubjectLabel;
+      examRow.class_id =
+        publishState.testAudience === TestAudienceEnum.SELECTED_CLASS
+          ? publishState.selectedClassId!
+          : null;
+      examRow.excluded_students = excludedStudents;
+      examRow.target_students = targetStudents;
+      examRow.updated_by = jwtPayload.id;
+      examRow.updated_user_name = jwtPayload.full_name;
+      examRow.updated_at = new Date();
+      await examRepo.save(examRow);
+
+      await this.persistWizardSubjects(manager, id, subjects, jwtPayload);
+
+      const reloaded = await examRepo.findOne({
+        where: { id },
+        relations: [
+          'questions',
+          'questionSections',
+          'questionSections.questions',
+          'questionSections.subject',
+          'class',
+          'excluded_students',
+          'target_students',
+          'primary_subject',
+        ],
+      });
+      if (!reloaded) throw new NotFoundException('Exam not found after update');
+
+      return this.formatExamResponse(reloaded, { includeCorrectAnswers: true });
+    });
+  }
+
+  /**
+   * Create sections + questions for an exam from the wizard subjects payload.
+   */
+  private async persistWizardSubjects(
+    manager: EntityManager,
+    examId: string,
+    subjects: CreateExamWizardDto['subjects'],
+    jwtPayload: JwtPayloadInterface,
+  ): Promise<void> {
+    const sectionRepo = manager.getRepository(ExamQuestionSectionEntity);
+    const questionRepo = manager.getRepository(ExamQuestionEntity);
+
+    let sectionOrder = 0;
+    for (const subj of subjects) {
+      const sectionPayload: DeepPartial<ExamQuestionSectionEntity> = {
+        exam_id: examId,
+        subject_id: subj.id,
+        section_type: 'mixed',
+        header_text: null,
+        instruction: null,
+        sort_order: sectionOrder++,
+        created_by: jwtPayload.id,
+        created_user_name: jwtPayload.full_name,
+        created_at: new Date(),
+      };
+      const section = sectionRepo.create(sectionPayload);
+      const savedSec = await sectionRepo.save(section);
+
+      let qOrder = 0;
+      for (const raw of subj.questions) {
+        const parsed = parseWizardQuestion(raw);
+        if (parsed.kind === 'passage') {
+          qOrder = await this.persistPassageQuestion(
+            questionRepo,
+            examId,
+            savedSec.id,
+            parsed.data,
+            qOrder,
+            jwtPayload,
+          );
+        } else if (parsed.kind === 'graded') {
+          await this.persistAutoScoredQuestion(
+            questionRepo,
+            examId,
+            savedSec.id,
+            parsed.data,
+            qOrder++,
+            jwtPayload,
+            QuestionCategoryEnum.GRADED,
+            null,
+          );
+        } else {
+          await this.persistUngradedQuestion(
+            questionRepo,
+            examId,
+            savedSec.id,
+            parsed.data,
+            qOrder++,
+            jwtPayload,
+          );
+        }
+      }
+    }
   }
 
   async updateExcludedStudents(

--- a/backend/src/exams/student-exam.service.ts
+++ b/backend/src/exams/student-exam.service.ts
@@ -31,6 +31,7 @@ import {
 import { ClassEntity } from 'src/classes/entities/class.entity';
 import { ClassStudentEntity, ClassStudentStatusEnum } from 'src/classes/entities/class-student.entity';
 import { UserEntity } from 'src/user/entities/user.entity';
+import { ActiveStatusEnum } from 'src/common/enums/active-status.enum';
 import { SmsService } from 'src/sms/sms.service';
 import {
   StartExamDto,
@@ -239,6 +240,7 @@ export class StudentExamService {
         .leftJoinAndSelect('questionSections.subject', 'sectionSubject')
         .leftJoin('exam.excluded_students', 'excluded')
         .where('exam.class_id IN (:...classIds)', { classIds })
+        .andWhere('exam.is_active = :active', { active: ActiveStatusEnum.ACTIVE })
         .andWhere('(excluded.id IS NULL OR excluded.id != :studentId)', { studentId });
 
       if (!includePast) {
@@ -255,9 +257,10 @@ export class StudentExamService {
       .leftJoinAndSelect('exam.class', 'class')
       .leftJoinAndSelect('exam.primary_subject', 'primary_subject')
       .leftJoinAndSelect('exam.questionSections', 'questionSections')
-      .leftJoinAndSelect('questionSections.subject', 'sectionSubject');
+      .leftJoinAndSelect('questionSections.subject', 'sectionSubject')
+      .where('exam.is_active = :active', { active: ActiveStatusEnum.ACTIVE });
     if (!includePast) {
-      targetQuery = targetQuery.where('exam.exam_end_time > :now', { now });
+      targetQuery = targetQuery.andWhere('exam.exam_end_time > :now', { now });
     }
     targetQuery = targetQuery.orderBy('exam.exam_start_time', sortOrder);
     const targetExams = await targetQuery.getMany();
@@ -401,6 +404,15 @@ export class StudentExamService {
         canAccess: false,
         reason: 'Exam not found',
         reason_code: ExamAccessReasonCodeEnum.NOT_ASSIGNED,
+      };
+    }
+
+    if (exam.is_active !== ActiveStatusEnum.ACTIVE) {
+      return {
+        canAccess: false,
+        reason: 'This exam is not available',
+        reason_code: ExamAccessReasonCodeEnum.NOT_ASSIGNED,
+        exam,
       };
     }
 

--- a/frontend/app/tests/[id]/page.tsx
+++ b/frontend/app/tests/[id]/page.tsx
@@ -1,0 +1,12 @@
+import PageLayout from "@/component/Layout";
+import ExamDetails from "@/component/Tests/ExamDetails";
+
+export default async function ExamDetailsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return (
+    <PageLayout route="/tests" subText="Test details">
+      <ExamDetails examId={id} />
+    </PageLayout>
+  );
+}

--- a/frontend/app/tests/create/page.tsx
+++ b/frontend/app/tests/create/page.tsx
@@ -1,11 +1,20 @@
+import { Suspense } from "react";
 import PageLayout from "@/component/Layout";
 import CreateTestForm from "@/component/Tests/CreateTestForm";
 
-export default function CreateTestsPage() {
+export default async function CreateTestsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ examId?: string }>;
+}) {
+  const { examId } = await searchParams;
+
   return (
-    <PageLayout route="/tests" subText="Create test">
+    <PageLayout route="/tests" subText={examId ? "Edit test" : "Create test"}>
       <div className="w-full max-w-[896px] mx-auto">
-        <CreateTestForm />
+        <Suspense fallback={null}>
+          <CreateTestForm />
+        </Suspense>
       </div>
     </PageLayout>
   );

--- a/frontend/component/Classes/TestCard.tsx
+++ b/frontend/component/Classes/TestCard.tsx
@@ -1,7 +1,6 @@
 import { useAppDispatch } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
 import CalenderIconSVG from "../svg/CalenderIconSVG";
-import HumanAddIconSVG from "../svg/HumanAddIconSvg";
 import PlayIconSVG from "../svg/PlayIconSVG";
 import ShareIconSVG from "../svg/ShareIconSVG";
 import { setNewTestCreated } from "@/lib/features/testSlice";
@@ -41,6 +40,7 @@ const TestCard = ({
   const submissionProgress = participantCount > 0 ? (submittedCount / participantCount) * 100 : 0;
   const isStudent = role === "STUDENT";
   const isTeacher = role === "TEACHER";
+  const isExamDisabled = isTeacher && "is_active" in testData && testData.is_active === 0;
 
   // const testStatus = "pending" as "ongoing" | "completed" | "pending";
   const testStatus = testData.status;
@@ -62,7 +62,9 @@ const TestCard = ({
   };
 
   const handlePrimaryAction = () => {
-   
+    if (isTeacher) {
+      router.push(`/tests/${testData.id}`);
+    }
   };
 
   return (
@@ -74,12 +76,25 @@ const TestCard = ({
         <h2 className="text-[18px] font-[500] leading-[100%] tracking-[-0.02em] text-[#49734F]">
           {testData.test_name}
         </h2>
-        <span
-          style={{ background: statusColors[testStatus] }}
-          className={`px-2 py-1 text-[12px] font-[500] leading-[12px] tracking-[-0.02em] text-[${statusTextColors[testStatus]}] border border-[${statusTextColors[testStatus]}] rounded-[27px] box-border`}
-        >
-          {testStatus}
-        </span>
+        <div className="flex items-center gap-2">
+          {isTeacher && "is_active" in testData && (
+            <span
+              className={`px-2 py-1 text-[12px] font-[500] leading-[12px] tracking-[-0.02em] rounded-[27px] box-border border ${
+                isExamDisabled
+                  ? "text-[#B42318] border-[#B42318] bg-[#B4231815]"
+                  : "text-[#49734F] border-[#49734F] bg-[rgba(73,115,79,0.15)]"
+              }`}
+            >
+              {isExamDisabled ? "Disabled" : "Enabled"}
+            </span>
+          )}
+          <span
+            style={{ background: statusColors[testStatus] }}
+            className={`px-2 py-1 text-[12px] font-[500] leading-[12px] tracking-[-0.02em] text-[${statusTextColors[testStatus]}] border border-[${statusTextColors[testStatus]}] rounded-[27px] box-border`}
+          >
+            {testStatus}
+          </span>
+        </div>
       </div>
       <div className="w-full flex flex-wrap items-center justify-between gap-y-2">
         {from === "testList" && (
@@ -128,26 +143,17 @@ const TestCard = ({
         </div>
         <div className="flex items-center gap-2 text-[#747775]">
           {from === "testList" && isTeacher && (
-            <>
-              <button
-                title="Add Students"
-                className="w-8 h-8 flex justify-center items-center rounded-[8px] hover:bg-[#EFF0F3]"
-                // onClick={() => dispatch(setOpenAddStudentModal(classItem))}
-              >
-                <HumanAddIconSVG width={16} />
-              </button>
-              <button
-                title="Share Tests"
-                className="w-8 h-8 flex justify-center items-center rounded-[8px] hover:bg-[#EFF0F3]"
-                onClick={() => {
-                  if (isTeacherExamListItem(testData)) {
-                    dispatch(setNewTestCreated({ type: "existing", test: testData }));
-                  }
-                }}
-              >
-                <ShareIconSVG width={16} />
-              </button>
-            </>
+            <button
+              title="Share Tests"
+              className="w-8 h-8 flex justify-center items-center rounded-[8px] hover:bg-[#EFF0F3]"
+              onClick={() => {
+                if (isTeacherExamListItem(testData)) {
+                  dispatch(setNewTestCreated({ type: "existing", test: testData }));
+                }
+              }}
+            >
+              <ShareIconSVG width={16} />
+            </button>
           )}
 
           {isStudentOngoingTest ? (
@@ -178,11 +184,13 @@ const TestCard = ({
                 e.currentTarget.style.color = statusTextColors[testStatus];
               }}
             >
-              {testStatus === "ongoing"
+              {isTeacher
                 ? "View details"
-                : testStatus === "completed"
-                  ? "View results"
-                  : "Continue marking"}
+                : testStatus === "ongoing"
+                  ? "View details"
+                  : testStatus === "completed"
+                    ? "View results"
+                    : "Continue marking"}
             </button>
           )}
         </div>

--- a/frontend/component/Tests/Create/useCreateTestFlow.ts
+++ b/frontend/component/Tests/Create/useCreateTestFlow.ts
@@ -7,6 +7,7 @@ import { useAppDispatch } from "@/lib/hooks";
 import { collectQuestionValidationFailures, getSubjectQuestionCount } from "@/utils/createTestValidation";
 import { useToast } from "@/component/Toast/ToastContext";
 import useCreateTest from "@/hooks/api/tests/useCreateTest";
+import useUpdateTest from "@/hooks/api/tests/useUpdateTest";
 
 const handlePublishStateForSubmission = (publishState: PublishState) => {
   const result: PublishStateForPayload = {
@@ -27,8 +28,12 @@ const handlePublishStateForSubmission = (publishState: PublishState) => {
 const useCreateTestFlow = (createTestState: CreateTestState) => {
   const dispatch = useAppDispatch();
   const { triggerToast } = useToast();
-  const [mutate, { loading }] = useCreateTest();
-  const { currentStep, formState, subjects, publishState } = createTestState;
+  const { currentStep, formState, subjects, publishState, editExamId } = createTestState;
+  const [createMutate, { loading: createLoading }] = useCreateTest();
+  const [updateMutate, { loading: updateLoading }] = useUpdateTest(editExamId);
+  const isEditing = Boolean(editExamId);
+  const mutate = isEditing ? updateMutate : createMutate;
+  const loading = isEditing ? updateLoading : createLoading;
 
   const handleNextStep = useCallback(async () => {
     if (currentStep === "Basic info") {

--- a/frontend/component/Tests/CreateTestForm.tsx
+++ b/frontend/component/Tests/CreateTestForm.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useRef } from "react";
-import { useAppSelector } from "@/lib/hooks";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { AxiosError } from "axios";
+import { RotatingLines } from "react-loader-spinner";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import axiosReq from "@/lib/axios";
+import { hydrateFromExam, resetForm } from "@/lib/features/createTestSlice";
+import { useApiError } from "@/hooks/api/useApiError";
 import CreateTestFooter from "./Create/CreateTestFooter";
 import CreateTestStepContent from "./Create/CreateTestStepContent";
 import CreateTestStepSidebar from "./Create/CreateTestStepSidebar";
@@ -12,6 +18,70 @@ const CreateTestForm = () => {
   const { currentStep, formState } = createTestState;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { handleNextStep, handlePreviousStep, isFirstStep, isSubmitting } = useCreateTestFlow(createTestState);
+
+  const dispatch = useAppDispatch();
+  const searchParams = useSearchParams();
+  const examId = searchParams.get("examId");
+  const { handleError } = useApiError();
+  const [hydrating, setHydrating] = useState(Boolean(examId));
+
+  useEffect(() => {
+    let active = true;
+
+    const loadExamForEdit = async () => {
+      if (!examId) {
+        if (createTestState.editExamId) {
+          dispatch(resetForm());
+        }
+        setHydrating(false);
+        return;
+      }
+
+      if (createTestState.editExamId === examId) {
+        setHydrating(false);
+        return;
+      }
+
+      setHydrating(true);
+      try {
+        const response = await axiosReq.get(`${process.env.NEXT_PUBLIC_BASE_URL}/exams/${examId}`);
+        if (active) {
+          dispatch(hydrateFromExam(response.data.payload));
+        }
+      } catch (error) {
+        handleError(error as AxiosError<ApiError>);
+      } finally {
+        if (active) {
+          setHydrating(false);
+        }
+      }
+    };
+
+    void loadExamForEdit();
+
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [examId]);
+
+  if (hydrating) {
+    return (
+      <div className="flex min-h-[calc(100vh-96px)] items-center justify-center">
+        <RotatingLines
+          visible={true}
+          height="48"
+          width="48"
+          color="grey"
+          strokeWidth="5"
+          animationDuration="0.75"
+          ariaLabel="rotating-lines-loading"
+          wrapperStyle={{}}
+          wrapperClass=""
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-[calc(100vh-96px)] flex-col overflow-hidden lg:h-[calc(100vh-96px)]">

--- a/frontend/component/Tests/ExamDetails.tsx
+++ b/frontend/component/Tests/ExamDetails.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { AxiosError } from "axios";
+import { RotatingLines } from "react-loader-spinner";
+import axiosReq from "@/lib/axios";
+import { useToast } from "@/component/Toast/ToastContext";
+import { useApiError } from "@/hooks/api/useApiError";
+
+const formatOptions: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true,
+};
+
+const audienceLabels: Record<string, string> = {
+  anyone: "Anyone with the link",
+  selected_class: "Selected class",
+  specific_students: "Specific students",
+};
+
+const formatDate = (value?: string | null) =>
+  value ? new Date(value).toLocaleString("en-US", formatOptions) : "N/A";
+
+const countQuestions = (subjects: StudentExamSubject[]) =>
+  subjects.reduce(
+    (total, subject) =>
+      total +
+      subject.questions.reduce(
+        (count, question) => count + ("childQuestions" in question ? question.childQuestions.length : 1),
+        0,
+      ),
+    0,
+  );
+
+const sumMarks = (subjects: StudentExamSubject[]) =>
+  subjects.reduce(
+    (total, subject) =>
+      total +
+      subject.questions.reduce((marks, question) => {
+        if ("childQuestions" in question) {
+          return marks + question.childQuestions.reduce((childMarks, child) => childMarks + (child.points ?? 0), 0);
+        }
+        return marks + (question.points ?? 0);
+      }, 0),
+    0,
+  );
+
+const DetailRow = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex flex-col gap-1">
+    <p className="text-[14px] font-[400] leading-[16px] tracking-[-0.02em] text-[#747775]">{label}</p>
+    <p className="text-[16px] font-[600] leading-[20px] tracking-[-0.02em] text-[#232A25]">{value}</p>
+  </div>
+);
+
+const ExamDetails = ({ examId }: { examId: string }) => {
+  const router = useRouter();
+  const { triggerToast } = useToast();
+  const { handleError } = useApiError();
+
+  const [exam, setExam] = useState<TeacherExamDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  const fetchExam = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await axiosReq.get(`${process.env.NEXT_PUBLIC_BASE_URL}/exams/${examId}`);
+      setExam(response.data.payload as TeacherExamDetails);
+    } catch (error) {
+      handleError(error as AxiosError<ApiError>);
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [examId]);
+
+  useEffect(() => {
+    void fetchExam();
+  }, [fetchExam]);
+
+  const isDisabled = exam?.is_active === 0;
+  const startAt = exam?.publishState?.scheduleAt ?? null;
+  const endAt = exam?.publishState?.endingAt ?? null;
+
+  const canModify = useMemo(() => {
+    if (!startAt) {
+      return false;
+    }
+    return Date.now() < new Date(startAt).getTime();
+  }, [startAt]);
+
+  const handleToggleStatus = useCallback(async () => {
+    if (!exam) {
+      return;
+    }
+    setToggling(true);
+    try {
+      const response = await axiosReq.patch(`${process.env.NEXT_PUBLIC_BASE_URL}/exams/${examId}/status`, {
+        active: isDisabled,
+      });
+      triggerToast({
+        title: "Success",
+        description: response.data.message || "Exam status updated.",
+        type: "success",
+      });
+      await fetchExam();
+    } catch (error) {
+      handleError(error as AxiosError<ApiError>);
+    } finally {
+      setToggling(false);
+    }
+  }, [exam, examId, fetchExam, handleError, isDisabled, triggerToast]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-232px)] items-center justify-center">
+        <RotatingLines
+          visible={true}
+          height="48"
+          width="48"
+          color="grey"
+          strokeWidth="5"
+          animationDuration="0.75"
+          ariaLabel="rotating-lines-loading"
+          wrapperStyle={{}}
+          wrapperClass=""
+        />
+      </div>
+    );
+  }
+
+  if (!exam) {
+    return (
+      <div className="flex min-h-[calc(100vh-232px)] flex-col items-center justify-center gap-4">
+        <p className="text-[18px] font-[600] text-[#232A25]">Test not found</p>
+        <button
+          type="button"
+          onClick={() => router.push("/tests")}
+          className="rounded-[8px] bg-[#49734F] px-4 py-2 text-[14px] font-[500] text-white"
+        >
+          Back to tests
+        </button>
+      </div>
+    );
+  }
+
+  const subjectNames = exam.subjects?.map((subject) => subject.name).filter(Boolean).join(", ") || "N/A";
+  const questionCount = countQuestions(exam.subjects ?? []);
+  const totalMarks = sumMarks(exam.subjects ?? []);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[896px] flex-col gap-6 py-2">
+      <div className="flex flex-col gap-4 rounded-[12px] bg-[#EFF0F3BF] p-4 sm:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-[24px] font-[600] leading-[28px] tracking-[-0.04em] text-[#232A25]">
+              {exam.test_name}
+            </h1>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-[27px] border border-[#49734F] bg-[rgba(73,115,79,0.15)] px-2 py-1 text-[12px] font-[500] capitalize text-[#49734F]">
+                {exam.status}
+              </span>
+              <span
+                className={`rounded-[27px] border px-2 py-1 text-[12px] font-[500] ${
+                  isDisabled
+                    ? "border-[#B42318] bg-[#B4231815] text-[#B42318]"
+                    : "border-[#49734F] bg-[rgba(73,115,79,0.15)] text-[#49734F]"
+                }`}
+              >
+                {isDisabled ? "Disabled" : "Enabled"}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex items-center gap-2">
+              <Link
+                href={canModify ? `/tests/create?examId=${exam.id}` : "#"}
+                aria-disabled={!canModify}
+                onClick={(event) => {
+                  if (!canModify) {
+                    event.preventDefault();
+                  }
+                }}
+                className={`rounded-[8px] px-4 py-2 text-[14px] font-[500] transition-colors ${
+                  canModify
+                    ? "bg-[#49734F] text-white hover:bg-[#3f6244]"
+                    : "cursor-not-allowed bg-[#E5E5E5] text-[#A0A4A1]"
+                }`}
+              >
+                Edit
+              </Link>
+              <button
+                type="button"
+                onClick={handleToggleStatus}
+                disabled={!canModify || toggling}
+                className={`rounded-[8px] border px-4 py-2 text-[14px] font-[500] transition-colors ${
+                  !canModify || toggling
+                    ? "cursor-not-allowed border-[#E5E5E5] bg-[#E5E5E5] text-[#A0A4A1]"
+                    : isDisabled
+                      ? "border-[#49734F] bg-white text-[#49734F] hover:bg-[#49734F] hover:text-white"
+                      : "border-[#B42318] bg-white text-[#B42318] hover:bg-[#B42318] hover:text-white"
+                }`}
+              >
+                {toggling ? "Saving..." : isDisabled ? "Enable" : "Disable"}
+              </button>
+            </div>
+            {!canModify && (
+              <p className="max-w-[260px] text-right text-[12px] font-[400] leading-[16px] text-[#747775]">
+                This test has started or ended. It can no longer be edited or disabled.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 rounded-[12px] bg-[#EFF0F3BF] p-4 sm:grid-cols-2 sm:p-6">
+        <DetailRow label="Subject(s)" value={subjectNames} />
+        <DetailRow label="Audience" value={audienceLabels[exam.publishState?.testAudience] ?? "N/A"} />
+        <DetailRow label="Class" value={exam.class_name ?? "N/A"} />
+        <DetailRow label="Duration" value={`${exam.formState?.duration ?? 0} min`} />
+        <DetailRow label="Starts" value={formatDate(startAt)} />
+        <DetailRow label="Ends" value={formatDate(endAt)} />
+        <DetailRow label="Questions" value={questionCount} />
+        <DetailRow label="Total marks" value={totalMarks} />
+        <DetailRow
+          label="Passing score"
+          value={exam.formState?.passingScore !== "" && exam.formState?.passingScore != null ? exam.formState.passingScore : "N/A"}
+        />
+        <DetailRow
+          label="Negative marking"
+          value={
+            exam.formState?.allowNegativeMarking ? `${exam.formState?.negativeMarking ?? 0}%` : "Disabled"
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-4 rounded-[12px] bg-[#EFF0F3BF] p-4 sm:p-6">
+        <h2 className="text-[18px] font-[600] leading-[24px] tracking-[-0.02em] text-[#232A25]">Subjects</h2>
+        <div className="flex flex-col gap-2">
+          {(exam.subjects ?? []).map((subject) => (
+            <div
+              key={subject.id}
+              className="flex items-center justify-between rounded-[8px] bg-white px-4 py-3"
+            >
+              <p className="text-[16px] font-[500] text-[#232A25]">{subject.name}</p>
+              <p className="text-[14px] font-[400] text-[#747775]">
+                {subject.questions.reduce(
+                  (count, question) =>
+                    count + ("childQuestions" in question ? question.childQuestions.length : 1),
+                  0,
+                )}{" "}
+                questions
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={() => router.push("/tests")}
+          className="text-[14px] font-[500] text-[#49734F] underline"
+        >
+          Back to tests
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExamDetails;

--- a/frontend/hooks/api/tests/useUpdateTest.ts
+++ b/frontend/hooks/api/tests/useUpdateTest.ts
@@ -1,0 +1,51 @@
+import { useToast } from "@/component/Toast/ToastContext";
+import axiosReq from "@/lib/axios";
+import { AxiosError, AxiosResponse } from "axios";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useApiError } from "../useApiError";
+import { useDispatch } from "react-redux";
+import { resetForm } from "@/lib/features/createTestSlice";
+
+const useUpdateTest = (examId: string | null) => {
+  const { triggerToast } = useToast();
+  const { handleError } = useApiError();
+  const [loading, setLoading] = useState(false);
+  const { push } = useRouter();
+  const dispatch = useDispatch();
+
+  const mutate = async (createTestPayload: CreateTestPayload) => {
+    if (!examId) {
+      return;
+    }
+
+    setLoading(true);
+
+    return axiosReq
+      .put<ApiResponse<ITest>, AxiosResponse<ApiResponse<ITest>>, CreateTestPayload>(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/exams/${examId}`,
+        createTestPayload,
+      )
+      .then(async (response) => {
+        if (response.status === 200 || response.status === 201) {
+          triggerToast({
+            title: "Success",
+            description: response.data.message || "Your test was updated successfully.",
+            type: "success",
+          });
+          dispatch(resetForm());
+          push(`/tests/${examId}`);
+        }
+      })
+      .catch((error: AxiosError<ApiError>) => {
+        handleError(error);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return [mutate, { loading }] as const;
+};
+
+export default useUpdateTest;

--- a/frontend/lib/features/create-test/createInitialState.ts
+++ b/frontend/lib/features/create-test/createInitialState.ts
@@ -12,6 +12,7 @@ const createInitialPublishState = (): PublishState => ({
 
 const createInitialState = (): CreateTestState => ({
   currentStep: createTestSteps[0],
+  editExamId: null,
   formState: {
     testName: "",
     duration: "",

--- a/frontend/lib/features/create-test/hydrateFromExam.ts
+++ b/frontend/lib/features/create-test/hydrateFromExam.ts
@@ -1,0 +1,122 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import createInitialState from "./createInitialState";
+import { createSubject } from "./createTestDomain";
+
+type ApiOption = { id: string; text: string; image?: string | null };
+
+type ApiQuestion = {
+  id: string;
+  type?: string;
+  subType?: string;
+  text?: string;
+  instruction?: string | null;
+  points?: number | null;
+  options?: ApiOption[];
+  matchingOptions?: { left: ApiOption[]; right: ApiOption[] };
+  answer?: { type: QuestionAnswerType; value: string[] };
+  passageText?: string;
+  childQuestions?: ApiQuestion[];
+};
+
+const mapOptions = (options?: ApiOption[]): QuestionOption[] | undefined =>
+  options?.map((option) => ({ id: option.id, text: option.text ?? "", image: null }));
+
+const mapGradedQuestion = (question: ApiQuestion): QuestionItem => ({
+  id: question.id,
+  type: "graded",
+  subType: question.subType ?? "",
+  text: question.text ?? "",
+  instruction: question.instruction ?? "",
+  image: null,
+  options: mapOptions(question.options),
+  matchingOptions: question.matchingOptions
+    ? {
+        left: mapOptions(question.matchingOptions.left) ?? [],
+        right: mapOptions(question.matchingOptions.right) ?? [],
+      }
+    : undefined,
+  answer: question.answer ? { type: question.answer.type, value: [...question.answer.value] } : undefined,
+  points: Number(question.points ?? 2),
+  showValidation: false,
+});
+
+const mapUngradedQuestion = (question: ApiQuestion): QuestionItem => ({
+  id: question.id,
+  type: "ungraded",
+  subType: question.subType ?? "",
+  text: question.text ?? "",
+  instruction: question.instruction ?? "",
+  image: null,
+  answer: undefined,
+  points: Number(question.points ?? 2),
+  showValidation: false,
+});
+
+const mapRootQuestion = (question: ApiQuestion): RootQuestionItem => {
+  if (question.type === "passage-question" || Array.isArray(question.childQuestions)) {
+    return {
+      id: question.id,
+      type: "passage-question",
+      passageText: question.passageText ?? "",
+      childQuestions: (question.childQuestions ?? []).map(mapGradedQuestion),
+      showValidation: false,
+    };
+  }
+
+  if (question.type === "ungraded") {
+    return mapUngradedQuestion(question);
+  }
+
+  return mapGradedQuestion(question);
+};
+
+const toStringOrEmpty = (value: number | string | null | undefined): string => {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  return String(value);
+};
+
+const hydrateFromExam = (_state: CreateTestState, action: PayloadAction<TeacherExamDetails>): CreateTestState => {
+  const exam = action.payload;
+  const initial = createInitialState();
+
+  const subjects = (exam.subjects ?? []).map((subject) =>
+    createSubject(
+      {
+        id: subject.id,
+        name: subject.name ?? "",
+        value: subject.code ?? subject.id,
+      },
+      ((subject.questions ?? []) as unknown as ApiQuestion[]).map(mapRootQuestion),
+    ),
+  );
+
+  return {
+    ...initial,
+    editExamId: exam.id,
+    formState: {
+      testName: exam.formState?.testName ?? "",
+      duration: toStringOrEmpty(exam.formState?.duration),
+      passingScore: toStringOrEmpty(exam.formState?.passingScore),
+      allowNegativeMarking: Boolean(exam.formState?.allowNegativeMarking),
+      negativeMarking: toStringOrEmpty(exam.formState?.negativeMarking),
+    },
+    subjects,
+    activeSubjectId: subjects[0]?.id ?? null,
+    publishState: {
+      publishTiming: exam.publishState?.publishTiming === "later" ? "later" : "immediately",
+      scheduleAt: exam.publishState?.scheduleAt
+        ? new Date(exam.publishState.scheduleAt).toISOString()
+        : initial.publishState.scheduleAt,
+      endingAt: exam.publishState?.endingAt
+        ? new Date(exam.publishState.endingAt).toISOString()
+        : initial.publishState.endingAt,
+      testAudience: (exam.publishState?.testAudience as TestAudience) ?? "anyone",
+      selectedClassId: exam.publishState?.selectedClassId ?? exam.class_id ?? "",
+      excluded_students: exam.publishState?.excluded_students ?? [],
+    },
+  };
+};
+
+export default hydrateFromExam;

--- a/frontend/lib/features/createTestSlice.ts
+++ b/frontend/lib/features/createTestSlice.ts
@@ -13,6 +13,7 @@ import duplicateQuestionReducer from "./create-test/duplicateQuestion";
 import finishDraggingReducer from "./create-test/finishDragging";
 import goToNextStepReducer from "./create-test/goToNextStep";
 import goToPreviousStepReducer from "./create-test/goToPreviousStep";
+import hydrateFromExamReducer from "./create-test/hydrateFromExam";
 import moveQuestionReducer from "./create-test/moveQuestion";
 import removeExcludedStudentReducer from "./create-test/removeExcludedStudent";
 import removeMatchingPairReducer from "./create-test/removeMatchingPair";
@@ -48,6 +49,7 @@ export const createTestSlice = createSlice({
   initialState,
   reducers: {
     resetForm: resetFormReducer,
+    hydrateFromExam: hydrateFromExamReducer,
     goToNextStep: goToNextStepReducer,
     goToPreviousStep: goToPreviousStepReducer,
     setFormField: setFormFieldReducer,
@@ -92,6 +94,7 @@ export const createTestSlice = createSlice({
 
 export const {
   resetForm,
+  hydrateFromExam,
   addMatchingPair,
   addOption,
   addQuestion,

--- a/frontend/types/api/exam.d.ts
+++ b/frontend/types/api/exam.d.ts
@@ -193,6 +193,7 @@ interface TeacherExamListItem {
   id: string;
   test_name: string;
   status: "ongoing" | "completed" | "pending";
+  is_active?: number;
   formState: StudentExamFormState;
   publishState: TeacherExamPublishState;
   subjects: StudentExamSubject[];
@@ -204,6 +205,22 @@ interface TeacherExamListItem {
   updated_at: string | null;
   participant_count: number;
   submitted_count: number;
+}
+
+interface TeacherExamDetails {
+  id: string;
+  test_name: string;
+  status: "ongoing" | "completed" | "pending";
+  is_active?: number;
+  formState: StudentExamFormState;
+  publishState: TeacherExamPublishState;
+  subjects: StudentExamSubject[];
+  class_id: string | null;
+  class_name: string | null;
+  created_by?: string;
+  created_user_name?: string;
+  created_at?: string;
+  updated_at?: string | null;
 }
 
 interface StudentAssignedExamListItem {

--- a/frontend/types/createTest.d.ts
+++ b/frontend/types/createTest.d.ts
@@ -230,6 +230,7 @@ type SetPublishFieldPayload = {
 
 type CreateTestState = {
   currentStep: CreateTestStep;
+  editExamId: string | null;
   formState: FormState;
   subjects: SubjectItem[];
   activeSubjectId: string | null;


### PR DESCRIPTION
- Add backend PUT /exams/:id (wizard update) and PATCH /exams/:id/status, both restricted to the owner/admin and only before the exam start time
- Hide disabled exams from students (assigned list, upcoming, access checks) and expose is_active in teacher exam responses
- Wire the "View details" button to a new /tests/[id] details page where a teacher can edit or enable/disable an exam before it starts
- Reuse the create-test wizard in edit mode by hydrating it from the exam
- Remove the add-students (human+) icon from the test card and show an enabled/disabled status badge instead