### PR TITLE
fix(exams): reshape submission retrieved API response

### DIFF
--- a/backend/src/exams/student-exam.service.ts
+++ b/backend/src/exams/student-exam.service.ts
@@ -68,6 +68,11 @@ import {
   getAutoScoredQuestions,
   getManualQuestions,
 } from './utils/exam-grading.util';
+import {
+  buildSubmissionQuestions,
+  persistSubmissionScores,
+  resolveSubmissionScores,
+} from './utils/submission-response.util';
 
 export type ExamAccessValidation = {
   canAccess: boolean;
@@ -833,6 +838,7 @@ export class StudentExamService {
     if (hasSubjective) {
       await this.calculateSubjectiveMaxScore(submission.id, exam);
     }
+    await this.syncSubmissionScoresFromExam(submission.id, exam);
 
     const reason = dto.reason ?? ExamFinalizeReasonEnum.MANUAL;
     let status = ExamSubmissionStatusEnum.SUBMITTED;
@@ -1127,6 +1133,7 @@ export class StudentExamService {
     if (hasSubjective) {
       await this.calculateSubjectiveMaxScore(submission.id, exam);
     }
+    await this.syncSubmissionScoresFromExam(submission.id, exam);
 
     // Update submission status
     submission.status = autoSubmit 
@@ -1284,7 +1291,13 @@ export class StudentExamService {
     let correctCount = 0;
     let wrongCount = 0;
     let totalScore = 0;
-    let maxObjective = 0;
+
+    const objectiveQs = ordered.filter(
+      (q) =>
+        q.question_type === QuestionTypeEnum.OBJECTIVE ||
+        isAutoScoredQuestion(q.category, q.sub_type),
+    );
+    const maxObjective = objectiveQs.reduce((sum, q) => sum + (q.points ?? 1), 0);
 
     for (const answer of answers) {
       const question = questionMap.get(answer.question_id);
@@ -1296,7 +1309,6 @@ export class StudentExamService {
       if (!autoScored) continue;
 
       const pts = question.points ?? 1;
-      maxObjective += pts;
 
       let isCorrect = false;
       if (isAutoScoredQuestion(question.category, question.sub_type) && question.answer_json) {
@@ -1331,11 +1343,6 @@ export class StudentExamService {
       await this.answerRepo.save(answer);
     }
 
-    const objectiveQs = ordered.filter(
-      (q) =>
-        q.question_type === QuestionTypeEnum.OBJECTIVE ||
-        isAutoScoredQuestion(q.category, q.sub_type),
-    );
     const answeredObjectiveIds = new Set(
       answers
         .filter((a) => {
@@ -1543,63 +1550,18 @@ export class StudentExamService {
       where: { submission_id: submission.id },
     });
     const answerByQuestionId = new Map(answers.map((answer) => [answer.question_id, answer]));
+    const scores = resolveSubmissionScores(exam, answers);
+    persistSubmissionScores(submission, scores);
+    submission.updated_at = new Date();
+    await this.submissionRepo.save(submission);
 
-    const manualQuestions = getManualQuestions(exam).map((question) => {
+    const questions = buildSubmissionQuestions(exam, answerByQuestionId);
+    const manualQuestions = getManualQuestions(exam);
+    const autoQuestions = getAutoScoredQuestions(exam);
+    const manualGradedCount = manualQuestions.filter((question) => {
       const answer = answerByQuestionId.get(question.id);
-      const marksObtained =
-        answer?.marks_obtained !== undefined && answer?.marks_obtained !== null
-          ? Number(answer.marks_obtained)
-          : null;
-
-      return {
-        question_id: question.id,
-        question: question.question,
-        instruction: question.instruction ?? null,
-        image_url: question.image_url ?? null,
-        points: question.points ?? question.marks_per_question ?? 0,
-        sub_type: question.sub_type,
-        sample_answer: question.sample_answer ?? this.extractSampleAnswer(question),
-        expected_word_limit: question.expected_word_limit ?? null,
-        student_answer: {
-          text_answer: answer?.text_answer ?? null,
-          word_count: answer?.word_count ?? null,
-        },
-        marks_obtained: marksObtained,
-        is_graded: marksObtained !== null,
-      };
-    });
-
-    const autoQuestions = getAutoScoredQuestions(exam).map((question) => {
-      const answer = answerByQuestionId.get(question.id);
-      const correctOptionIds = new Set(question.answer_json?.value ?? []);
-      const options = (question.options_json ?? []).map((option) => ({
-        id: option.id,
-        text: option.text,
-        is_correct: correctOptionIds.has(option.id),
-      }));
-
-      return {
-        question_id: question.id,
-        question: question.question,
-        instruction: question.instruction ?? null,
-        image_url: question.image_url ?? null,
-        points: question.points ?? 1,
-        sub_type: question.sub_type,
-        options,
-        student_selected: answer
-          ? this.resolveSubmittedAnswerValue(answer, question)
-          : null,
-        selected_answer: answer?.selected_answer ?? null,
-        text_answer: answer?.text_answer ?? null,
-        is_correct: answer?.is_correct ?? null,
-        marks_obtained:
-          answer?.marks_obtained !== undefined && answer?.marks_obtained !== null
-            ? Number(answer.marks_obtained)
-            : null,
-      };
-    });
-
-    const manualGradedCount = manualQuestions.filter((question) => question.is_graded).length;
+      return answer?.marks_obtained !== undefined && answer?.marks_obtained !== null;
+    }).length;
 
     return {
       submission: {
@@ -1611,23 +1573,23 @@ export class StudentExamService {
         phone: submission.student?.phone ?? null,
         submitted_at: submission.submitted_at ?? null,
         status: submission.status,
-        total_score: submission.total_score ?? null,
-        max_score: submission.max_score ?? null,
-        percentage: computePercentage(submission.total_score, submission.max_score),
+        total_score: scores.total_score,
+        max_score: scores.max_score,
+        percentage: scores.percentage,
         is_graded: submission.is_graded,
         grading_status: submission.is_graded
           ? SubmissionGradingStatusEnum.GRADED
           : SubmissionGradingStatusEnum.PENDING,
       },
-      manual_questions: manualQuestions,
-      auto_questions: autoQuestions,
+      questions,
       totals: {
         manual_total_count: manualQuestions.length,
         manual_graded_count: manualGradedCount,
         auto_total_count: autoQuestions.length,
-        auto_graded_count: autoQuestions.filter(
-          (question) => question.marks_obtained !== null,
-        ).length,
+        auto_graded_count: autoQuestions.filter((question) => {
+          const answer = answerByQuestionId.get(question.id);
+          return answer?.marks_obtained !== undefined && answer?.marks_obtained !== null;
+        }).length,
       },
     };
   }
@@ -1681,7 +1643,7 @@ export class StudentExamService {
       }
     }
 
-    await this.recomputeSubmissionTotalScore(submission.id);
+    await this.recomputeSubmissionTotalScore(submission.id, exam);
 
     const answers = await this.answerRepo.find({
       where: { submission_id: submission.id },
@@ -1697,11 +1659,9 @@ export class StudentExamService {
     submission.graded_by = submission.is_graded ? jwtPayload.id : null;
     submission.updated_at = new Date();
     submission.updated_by = jwtPayload.id;
+    const scores = resolveSubmissionScores(exam, answers);
+    persistSubmissionScores(submission, scores);
     await this.submissionRepo.save(submission);
-
-    const refreshedSubmission = await this.submissionRepo.findOne({
-      where: { id: submission.id },
-    });
 
     const manualGradedCount = [...manualQuestionMap.values()].filter((question) => {
       const answer = answerByQuestionId.get(question.id);
@@ -1710,14 +1670,11 @@ export class StudentExamService {
 
     return {
       submission_id: submission.id,
-      total_score: refreshedSubmission?.total_score ?? null,
-      max_score: refreshedSubmission?.max_score ?? null,
-      percentage: computePercentage(
-        refreshedSubmission?.total_score,
-        refreshedSubmission?.max_score,
-      ),
-      is_graded: refreshedSubmission?.is_graded ?? false,
-      grading_status: refreshedSubmission?.is_graded
+      total_score: scores.total_score,
+      max_score: scores.max_score,
+      percentage: scores.percentage,
+      is_graded: submission.is_graded,
+      grading_status: submission.is_graded
         ? SubmissionGradingStatusEnum.GRADED
         : SubmissionGradingStatusEnum.PENDING,
       manual_graded_count: manualGradedCount,
@@ -1785,7 +1742,33 @@ export class StudentExamService {
     return submission;
   }
 
-  private async recomputeSubmissionTotalScore(submissionId: string): Promise<void> {
+  private async syncSubmissionScoresFromExam(
+    submissionId: string,
+    exam: ExamEntity,
+  ): Promise<void> {
+    const answers = await this.answerRepo.find({
+      where: { submission_id: submissionId },
+    });
+    const scores = resolveSubmissionScores(exam, answers);
+    await this.submissionRepo.update(
+      { id: submissionId },
+      {
+        total_score: scores.total_score,
+        max_score: scores.max_score,
+        updated_at: new Date(),
+      },
+    );
+  }
+
+  private async recomputeSubmissionTotalScore(
+    submissionId: string,
+    exam?: ExamEntity,
+  ): Promise<void> {
+    if (exam) {
+      await this.syncSubmissionScoresFromExam(submissionId, exam);
+      return;
+    }
+
     const answers = await this.answerRepo.find({
       where: { submission_id: submissionId },
     });

--- a/backend/src/exams/utils/submission-response.util.ts
+++ b/backend/src/exams/utils/submission-response.util.ts
@@ -1,0 +1,288 @@
+import { ExamEntity } from '../entities/exam.entity';
+import {
+  CORRECT_ANSWER_ENUM_BY_OPTION_INDEX,
+  ExamQuestionEntity,
+  QuestionTypeEnum,
+} from '../entities/exam-question.entity';
+import { StudentExamAnswerEntity, StudentExamSubmissionEntity } from '../entities/student-exam-answer.entity';
+import { AnswerValueTypeEnum, QuestionCategoryEnum } from '../enums/question.enums';
+import { buildResponseOptionId } from './exam-option-ids.util';
+import { computeExamTotalMarks, isManualGradingQuestion } from './exam-grading.util';
+import { isAutoScoredQuestion } from './exam-question.util';
+
+export type SubmissionOptionResponse = {
+  id: string;
+  text: string;
+  image_url: string | null;
+};
+
+export type SubmissionMatchingOptionResponse = {
+  id: string;
+  text: string;
+  image: string | null;
+};
+
+export type SubmissionAnswerResponse =
+  | {
+      type: 'optionId';
+      correct_answer: string[];
+      student_selected: string[];
+    }
+  | {
+      type: 'matchingOrdering';
+      correct_answer: string[];
+      student_selected: string[];
+    }
+  | {
+      type: 'text';
+      student_answer: string;
+    };
+
+export type SubmissionQuestionResponse = {
+  question_id: string;
+  question: string;
+  instruction: string;
+  image_url: string | null;
+  points: number;
+  type: string;
+  sub_type: string;
+  options?: SubmissionOptionResponse[];
+  matchingOptions?: {
+    left: SubmissionMatchingOptionResponse[];
+    right: SubmissionMatchingOptionResponse[];
+  };
+  answer: SubmissionAnswerResponse;
+  is_correct: boolean | null;
+  marks_obtained: number;
+};
+
+export type SubmissionPassageQuestionResponse = {
+  id: string;
+  type: 'passage-question';
+  passageText: string;
+  childQuestions: SubmissionQuestionResponse[];
+};
+
+export type SubmissionQuestionItem = SubmissionQuestionResponse | SubmissionPassageQuestionResponse;
+
+const getAllExamQuestions = (exam: ExamEntity): ExamQuestionEntity[] => {
+  if (exam.questionSections?.length) {
+    const sections = [...exam.questionSections].sort((a, b) => a.sort_order - b.sort_order);
+    const ordered: ExamQuestionEntity[] = [];
+    for (const section of sections) {
+      const questions = [...(section.questions || [])].sort((a, b) => a.sort_order - b.sort_order);
+      ordered.push(...questions);
+    }
+    return ordered;
+  }
+
+  return [...(exam.questions || [])].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+};
+
+export const getOrderedTopLevelQuestions = (exam: ExamEntity): ExamQuestionEntity[] =>
+  getAllExamQuestions(exam).filter((question) => !question.parent_id);
+
+const resolveStudentSelected = (
+  answer: StudentExamAnswerEntity | undefined,
+  question: ExamQuestionEntity,
+): string[] => {
+  if (!answer) {
+    return [];
+  }
+
+  if (question.sub_type === 'multiple-response') {
+    return (answer.text_answer ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  if (question.sub_type === 'matching-ordering') {
+    return (answer.text_answer ?? '')
+      .split('|')
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  if (answer.text_answer?.trim()) {
+    return [answer.text_answer.trim()];
+  }
+
+  if (answer.selected_answer && question.options_json?.length) {
+    const index = CORRECT_ANSWER_ENUM_BY_OPTION_INDEX.indexOf(answer.selected_answer);
+    if (index >= 0 && question.options_json[index]) {
+      return [question.options_json[index].id];
+    }
+  }
+
+  if (answer.selected_answer) {
+    const index = CORRECT_ANSWER_ENUM_BY_OPTION_INDEX.indexOf(answer.selected_answer);
+    if (index >= 0) {
+      return [buildResponseOptionId(question.id, index)];
+    }
+  }
+
+  return [];
+};
+
+const buildSubmissionAnswer = (
+  question: ExamQuestionEntity,
+  answer: StudentExamAnswerEntity | undefined,
+): SubmissionAnswerResponse => {
+  if (question.category === QuestionCategoryEnum.UNGRADED) {
+    return {
+      type: 'text',
+      student_answer: answer?.text_answer ?? '',
+    };
+  }
+
+  if (question.sub_type === 'matching-ordering') {
+    return {
+      type: 'matchingOrdering',
+      correct_answer: [...(question.answer_json?.value ?? [])],
+      student_selected: resolveStudentSelected(answer, question),
+    };
+  }
+
+  if (
+    question.question_type === QuestionTypeEnum.SUBJECTIVE &&
+    !isAutoScoredQuestion(question.category, question.sub_type)
+  ) {
+    return {
+      type: 'text',
+      student_answer: answer?.text_answer ?? '',
+    };
+  }
+
+  return {
+    type: 'optionId',
+    correct_answer: [...(question.answer_json?.value ?? [])],
+    student_selected: resolveStudentSelected(answer, question),
+  };
+};
+
+const formatSubmissionQuestion = (
+  question: ExamQuestionEntity,
+  answer: StudentExamAnswerEntity | undefined,
+  isPassageChild: boolean,
+): SubmissionQuestionResponse => {
+  const isManual =
+    question.category === QuestionCategoryEnum.UNGRADED || isManualGradingQuestion(question);
+
+  const response: SubmissionQuestionResponse = {
+    question_id: question.id,
+    question: question.question,
+    instruction: question.instruction ?? '',
+    image_url: question.image_url ?? null,
+    points: question.points ?? question.marks_per_question ?? 0,
+    type: isPassageChild
+      ? QuestionCategoryEnum.PASSAGE
+      : (question.category ?? QuestionCategoryEnum.GRADED),
+    sub_type: question.sub_type ?? '',
+    answer: buildSubmissionAnswer(question, answer),
+    is_correct: isManual
+      ? answer?.marks_obtained !== undefined && answer?.marks_obtained !== null
+        ? (answer.is_correct ?? null)
+        : null
+      : (answer?.is_correct ?? false),
+    marks_obtained:
+      answer?.marks_obtained !== undefined && answer?.marks_obtained !== null
+        ? Number(answer.marks_obtained)
+        : 0,
+  };
+
+  if (question.options_json?.length) {
+    response.options = question.options_json.map((option) => ({
+      id: option.id,
+      text: option.text,
+      image_url: null,
+    }));
+  }
+
+  if (question.sub_type === 'matching-ordering' && question.matching_options_json) {
+    response.matchingOptions = {
+      left: question.matching_options_json.left.map((option) => ({
+        id: option.id,
+        text: option.text,
+        image: null,
+      })),
+      right: question.matching_options_json.right.map((option) => ({
+        id: option.id,
+        text: option.text,
+        image: null,
+      })),
+    };
+  }
+
+  return response;
+};
+
+const formatSubmissionPassageQuestion = (
+  question: ExamQuestionEntity,
+  childrenByParent: Map<string, ExamQuestionEntity[]>,
+  answerByQuestionId: Map<string, StudentExamAnswerEntity>,
+): SubmissionPassageQuestionResponse => {
+  const children = (childrenByParent.get(question.id) ?? [])
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((child) =>
+      formatSubmissionQuestion(child, answerByQuestionId.get(child.id), true),
+    );
+
+  return {
+    id: question.id,
+    type: QuestionCategoryEnum.PASSAGE,
+    passageText: question.passage_text ?? question.question,
+    childQuestions: children,
+  };
+};
+
+export const buildSubmissionQuestions = (
+  exam: ExamEntity,
+  answerByQuestionId: Map<string, StudentExamAnswerEntity>,
+): SubmissionQuestionItem[] => {
+  const allQuestions = getAllExamQuestions(exam);
+  const childrenByParent = new Map<string, ExamQuestionEntity[]>();
+
+  for (const question of allQuestions) {
+    if (!question.parent_id) {
+      continue;
+    }
+    const list = childrenByParent.get(question.parent_id) ?? [];
+    list.push(question);
+    childrenByParent.set(question.parent_id, list);
+  }
+
+  return getOrderedTopLevelQuestions(exam).map((question) => {
+    if (question.category === QuestionCategoryEnum.PASSAGE && !question.parent_id) {
+      return formatSubmissionPassageQuestion(question, childrenByParent, answerByQuestionId);
+    }
+
+    return formatSubmissionQuestion(question, answerByQuestionId.get(question.id), false);
+  });
+};
+
+export const resolveSubmissionScores = (
+  exam: ExamEntity,
+  answers: StudentExamAnswerEntity[],
+): { total_score: number; max_score: number; percentage: number } => {
+  const max_score = computeExamTotalMarks(exam);
+  const total_score = answers.reduce((sum, answer) => {
+    if (answer.marks_obtained === undefined || answer.marks_obtained === null) {
+      return sum;
+    }
+    return sum + Number(answer.marks_obtained);
+  }, 0);
+
+  const percentage =
+    max_score > 0 ? Math.round((total_score / max_score) * 10000) / 100 : 0;
+
+  return { total_score, max_score, percentage };
+};
+
+export const persistSubmissionScores = (
+  submission: StudentExamSubmissionEntity,
+  scores: { total_score: number; max_score: number; percentage: number },
+): void => {
+  submission.total_score = scores.total_score;
+  submission.max_score = scores.max_score;
+};

--- a/frontend/types/api/grading.d.ts
+++ b/frontend/types/api/grading.d.ts
@@ -85,41 +85,66 @@ interface GradingSummaryResponse {
   meta: GradingPaginationMeta;
 }
 
-interface ManualGradingQuestion {
-  question_id: string;
-  question: string;
-  instruction: string | null;
+interface SubmissionOption {
+  id: string;
+  text: string;
   image_url: string | null;
-  points: number;
-  sub_type: string | null;
-  sample_answer: string | null;
-  expected_word_limit: number | null;
-  student_answer: {
-    text_answer: string | null;
-    word_count: number | null;
-  };
-  marks_obtained: number | null;
-  is_graded: boolean;
 }
 
-interface AutoGradingQuestion {
+interface SubmissionMatchingOption {
+  id: string;
+  text: string;
+  image: string | null;
+}
+
+interface SubmissionAnswerOptionId {
+  type: 'optionId';
+  correct_answer: string[];
+  student_selected: string[];
+}
+
+interface SubmissionAnswerMatchingOrdering {
+  type: 'matchingOrdering';
+  correct_answer: string[];
+  student_selected: string[];
+}
+
+interface SubmissionAnswerText {
+  type: 'text';
+  student_answer: string;
+}
+
+type SubmissionAnswer =
+  | SubmissionAnswerOptionId
+  | SubmissionAnswerMatchingOrdering
+  | SubmissionAnswerText;
+
+interface SubmissionQuestion {
   question_id: string;
   question: string;
-  instruction: string | null;
+  instruction: string;
   image_url: string | null;
   points: number;
-  sub_type: string | null;
-  options: Array<{
-    id: string;
-    text: string;
-    is_correct: boolean;
-  }>;
-  student_selected: string | null;
-  selected_answer: string | null;
-  text_answer: string | null;
+  type: string;
+  sub_type: string;
+  options?: SubmissionOption[];
+  matchingOptions?: {
+    left: SubmissionMatchingOption[];
+    right: SubmissionMatchingOption[];
+  };
+  answer: SubmissionAnswer;
   is_correct: boolean | null;
-  marks_obtained: number | null;
+  marks_obtained: number;
 }
+
+interface SubmissionPassageQuestion {
+  id: string;
+  type: 'passage-question';
+  passageText: string;
+  childQuestions: SubmissionQuestion[];
+}
+
+type SubmissionQuestionItem = SubmissionQuestion | SubmissionPassageQuestion;
 
 interface SubmissionGradingDetail {
   submission: {
@@ -131,14 +156,13 @@ interface SubmissionGradingDetail {
     phone: string | null;
     submitted_at: string | null;
     status: string;
-    total_score: number | null;
-    max_score: number | null;
-    percentage: number | null;
+    total_score: number;
+    max_score: number;
+    percentage: number;
     is_graded: boolean;
     grading_status: SubmissionGradingStatus;
   };
-  manual_questions: ManualGradingQuestion[];
-  auto_questions: AutoGradingQuestion[];
+  questions: SubmissionQuestionItem[];
   totals: {
     manual_total_count: number;
     manual_graded_count: number;
@@ -158,9 +182,9 @@ interface SaveSubmissionGradesPayload {
 
 interface SaveSubmissionGradesResponse {
   submission_id: string;
-  total_score: number | null;
-  max_score: number | null;
-  percentage: number | null;
+  total_score: number;
+  max_score: number;
+  percentage: number;
   is_graded: boolean;
   grading_status: SubmissionGradingStatus;
   manual_graded_count: number;


### PR DESCRIPTION
- Replace manual_questions/auto_questions with a single exam-order questions array including passage grouping and unified answer objects.
- Add submission-response.util for question formatting, student answer resolution, and score computation from all exam questions.
- Ensure total_score, max_score, and percentage are always numbers (never null) on retrieval, grading save, and exam submit.
- Fix calculateObjectiveScore to derive max_score from all auto-scored questions, not only answered rows.
- Update frontend SubmissionGradingDetail types to match the new shape.