### PR TITLE
feat: grading explanation field and Google sign-in

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -40,3 +40,12 @@ EMAIL_PASSWORD=your-app-password-here
 
 # Frontend URL (for invitation and share links)
 FRONTEND_URL=http://localhost:3000
+
+# Backend base URL (used for Google OAuth callback)
+BACKEND_BASE_URL=http://localhost:4000
+
+# Google OAuth (https://console.cloud.google.com/apis/credentials)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Optional override; defaults to BACKEND_BASE_URL/api/v1/auth/google/callback
+GOOGLE_CALLBACK_URL=

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Post, Body, UseGuards, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Get, HttpCode, HttpStatus, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
 import { AuthService } from './auth.service';
+import { GoogleAuthService } from './google-auth.service';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags, ApiBody } from '@nestjs/swagger';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { LoginDto } from './dto/login.dto';
@@ -18,7 +20,10 @@ import { VerifyOtpDto } from 'src/sms/dto/sms.dto';
   version: '1',
 })
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly googleAuthService: GoogleAuthService,
+  ) {}
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
@@ -214,6 +219,45 @@ export class AuthController {
   async login(@Body() loginDto: LoginDto) {
     const payload = await this.authService.login(loginDto);
     return { message: 'Login successful!', payload };
+  }
+
+  @Get('google')
+  @ApiOperation({
+    summary: 'Start Google sign-in',
+    description: 'Redirects the browser to Google OAuth consent screen.',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to Google OAuth' })
+  async googleAuth(@Res() res: Response) {
+    const url = this.googleAuthService.buildAuthorizationUrl();
+    return res.redirect(url);
+  }
+
+  @Get('google/callback')
+  @ApiOperation({
+    summary: 'Google OAuth callback',
+    description: 'Handles Google redirect, creates or links the user, then redirects to the frontend with tokens.',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to frontend callback page' })
+  async googleAuthCallback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Query('error') error: string,
+    @Res() res: Response,
+  ) {
+    if (error) {
+      return res.redirect(
+        this.googleAuthService.buildFrontendFailureRedirect('Google sign-in was cancelled'),
+      );
+    }
+
+    try {
+      const payload = await this.googleAuthService.handleCallback(code, state);
+      return res.redirect(this.googleAuthService.buildFrontendSuccessRedirect(payload));
+    } catch (callbackError) {
+      const message =
+        callbackError instanceof Error ? callbackError.message : 'Google sign-in failed';
+      return res.redirect(this.googleAuthService.buildFrontendFailureRedirect(message));
+    }
   }
 
   @Post('forgot-password')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { GoogleAuthService } from './google-auth.service';
 import { UserModule } from 'src/user/user.module';
 import { SmsModule } from 'src/sms/sms.module';
 import { EmailModule } from 'src/email/email.module';
@@ -28,6 +29,6 @@ import { RefreshTokenStrategy } from './strategies/refresh-token.strategy';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, RefreshTokenStrategy],
+  providers: [AuthService, GoogleAuthService, JwtStrategy, RefreshTokenStrategy],
 })
 export class AuthModule {}

--- a/backend/src/auth/google-auth.service.ts
+++ b/backend/src/auth/google-auth.service.ts
@@ -1,0 +1,180 @@
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { randomBytes } from 'crypto';
+import { UserService } from 'src/user/user.service';
+
+type GoogleTokenResponse = {
+  access_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+};
+
+type GoogleUserInfo = {
+  sub: string;
+  email?: string;
+  email_verified?: boolean | string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+};
+
+@Injectable()
+export class GoogleAuthService {
+  private readonly pendingStates = new Map<string, number>();
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly userService: UserService,
+  ) {}
+
+  private getClientId(): string {
+    const clientId = this.configService.get<string>('GOOGLE_CLIENT_ID');
+    if (!clientId) {
+      throw new BadRequestException('Google sign-in is not configured');
+    }
+    return clientId;
+  }
+
+  private getClientSecret(): string {
+    const clientSecret = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
+    if (!clientSecret) {
+      throw new BadRequestException('Google sign-in is not configured');
+    }
+    return clientSecret;
+  }
+
+  private getCallbackUrl(): string {
+    return (
+      this.configService.get<string>('GOOGLE_CALLBACK_URL') ??
+      `${this.getBackendBaseUrl()}/api/v1/auth/google/callback`
+    );
+  }
+
+  private getBackendBaseUrl(): string {
+    return this.configService.get<string>('BACKEND_BASE_URL', 'http://localhost:4000');
+  }
+
+  private getFrontendUrl(): string {
+    return this.configService.get<string>('FRONTEND_URL', 'http://localhost:3000');
+  }
+
+  private createStateToken(): string {
+    const state = randomBytes(24).toString('hex');
+    this.pendingStates.set(state, Date.now());
+    return state;
+  }
+
+  private assertValidState(state: string): void {
+    const createdAt = this.pendingStates.get(state);
+    this.pendingStates.delete(state);
+
+    if (!createdAt) {
+      throw new UnauthorizedException('Invalid or expired Google sign-in state');
+    }
+
+    const maxAgeMs = 10 * 60 * 1000;
+    if (Date.now() - createdAt > maxAgeMs) {
+      throw new UnauthorizedException('Google sign-in session expired. Please try again.');
+    }
+  }
+
+  buildAuthorizationUrl(): string {
+    const clientId = this.getClientId();
+    const redirectUri = encodeURIComponent(this.getCallbackUrl());
+    const state = this.createStateToken();
+    const scope = encodeURIComponent('openid email profile');
+
+    return (
+      `https://accounts.google.com/o/oauth2/v2/auth?` +
+      `client_id=${encodeURIComponent(clientId)}` +
+      `&redirect_uri=${redirectUri}` +
+      `&response_type=code` +
+      `&scope=${scope}` +
+      `&access_type=online` +
+      `&prompt=select_account` +
+      `&state=${state}`
+    );
+  }
+
+  async handleCallback(code: string, state: string) {
+    if (!code?.trim()) {
+      throw new BadRequestException('Missing Google authorization code');
+    }
+
+    this.assertValidState(state);
+
+    const tokenResponse = await axios.post<GoogleTokenResponse>(
+      'https://oauth2.googleapis.com/token',
+      new URLSearchParams({
+        code,
+        client_id: this.getClientId(),
+        client_secret: this.getClientSecret(),
+        redirect_uri: this.getCallbackUrl(),
+        grant_type: 'authorization_code',
+      }).toString(),
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      },
+    );
+
+    const accessToken = tokenResponse.data.access_token;
+    if (!accessToken) {
+      throw new UnauthorizedException('Failed to authenticate with Google');
+    }
+
+    const profileResponse = await axios.get<GoogleUserInfo>(
+      'https://www.googleapis.com/oauth2/v3/userinfo',
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+
+    const profile = profileResponse.data;
+    if (!profile.sub) {
+      throw new UnauthorizedException('Google profile is missing a user id');
+    }
+
+    if (!profile.email) {
+      throw new BadRequestException('Google account must have a verified email address');
+    }
+
+    const user = await this.userService.findOrCreateGoogleUser({
+      googleId: profile.sub,
+      email: profile.email.toLowerCase(),
+      fullName:
+        profile.name?.trim() ||
+        [profile.given_name, profile.family_name].filter(Boolean).join(' ').trim() ||
+        profile.email.split('@')[0],
+    });
+
+    return this.userService.generateTokenForUser(user);
+  }
+
+  buildFrontendSuccessRedirect(payload: Awaited<ReturnType<UserService['generateTokenForUser']>>): string {
+    const frontendUrl = this.getFrontendUrl().replace(/\/$/, '');
+    const params = new URLSearchParams({
+      access_token: payload.access_token,
+      refresh_token: payload.refresh_token ?? '',
+      role: payload.role,
+      id: payload.id,
+      full_name: payload.full_name ?? '',
+      email: payload.email ?? '',
+      phone: payload.phone ?? '',
+    });
+
+    return `${frontendUrl}/auth/google/callback?${params.toString()}`;
+  }
+
+  buildFrontendFailureRedirect(message: string): string {
+    const frontendUrl = this.getFrontendUrl().replace(/\/$/, '');
+    return `${frontendUrl}/auth/google/callback?error=${encodeURIComponent(message)}`;
+  }
+}

--- a/backend/src/exams/dto/grade-submission.dto.ts
+++ b/backend/src/exams/dto/grade-submission.dto.ts
@@ -8,6 +8,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MaxLength,
   Min,
   ValidateNested,
 } from 'class-validator';
@@ -24,6 +25,15 @@ export class QuestionGradeDto {
   @Min(0)
   @Type(() => Number)
   marks_obtained: number;
+
+  @ApiPropertyOptional({
+    description: 'Teacher feedback/explanation for manual (ungraded) questions',
+    maxLength: 2000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  explanation?: string;
 }
 
 export class GradeSubmissionDto {

--- a/backend/src/exams/entities/student-exam-answer.entity.ts
+++ b/backend/src/exams/entities/student-exam-answer.entity.ts
@@ -149,6 +149,12 @@ export class StudentExamAnswerEntity extends CustomBaseEntity {
   @Column({ name: 'marks_obtained', type: 'decimal', precision: 10, scale: 2, nullable: true })
   marks_obtained?: number;
 
+  @ApiPropertyOptional({
+    description: 'Teacher feedback/explanation when manually grading ungraded questions',
+  })
+  @Column({ name: 'grader_explanation', type: 'text', nullable: true })
+  grader_explanation?: string | null;
+
   @ApiPropertyOptional({ description: 'When the answer was last updated' })
   @Column({ name: 'answered_at', type: 'timestamp', nullable: true })
   answered_at?: Date;

--- a/backend/src/exams/student-exam.service.ts
+++ b/backend/src/exams/student-exam.service.ts
@@ -1628,6 +1628,9 @@ export class StudentExamService {
 
       if (answer) {
         answer.marks_obtained = grade.marks_obtained;
+        if (grade.explanation !== undefined) {
+          answer.grader_explanation = grade.explanation.trim() || null;
+        }
         answer.updated_at = new Date();
         answer.updated_by = jwtPayload.id;
         await this.answerRepo.save(answer);
@@ -1636,6 +1639,7 @@ export class StudentExamService {
           submission_id: submission.id,
           question_id: grade.question_id,
           marks_obtained: grade.marks_obtained,
+          grader_explanation: grade.explanation?.trim() || null,
           created_by: jwtPayload.id,
           created_at: new Date(),
         });

--- a/backend/src/exams/utils/submission-response.util.ts
+++ b/backend/src/exams/utils/submission-response.util.ts
@@ -36,6 +36,7 @@ export type SubmissionAnswerResponse =
   | {
       type: 'text';
       student_answer: string;
+      explanation?: string | null;
     };
 
 export type SubmissionQuestionResponse = {
@@ -133,6 +134,7 @@ const buildSubmissionAnswer = (
     return {
       type: 'text',
       student_answer: answer?.text_answer ?? '',
+      explanation: answer?.grader_explanation ?? null,
     };
   }
 
@@ -151,6 +153,7 @@ const buildSubmissionAnswer = (
     return {
       type: 'text',
       student_answer: answer?.text_answer ?? '',
+      explanation: answer?.grader_explanation ?? null,
     };
   }
 

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -67,4 +67,13 @@ export class UserEntity extends CustomBaseEntity {
   @Index({ unique: true })
   refresh_token: string;
 
+  @Column({
+    type: "varchar",
+    name: "google_id",
+    length: 255,
+    nullable: true,
+  })
+  @Index({ unique: true })
+  google_id: string | null;
+
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -4,12 +4,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { RegisterUserDto } from 'src/auth/dto/register-user.dto';
 import { LoginDto } from 'src/auth/dto/login.dto';
 import { ActiveStatusEnum } from 'src/common/enums/active-status.enum';
+import { RolesEnum } from 'src/common/enums/roles.enum';
 import { CryptoUtil } from 'src/common/utils/crypto.util';
 import { UserFilterUtil } from 'src/common/utils/user-filter.util';
 import { Repository } from 'typeorm';
 import { UserReponseDto } from './dto/user-response.dto';
 import { UserEntity } from './entities/user.entity';
 import { JwtService } from '@nestjs/jwt';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class UserService {
@@ -82,6 +84,70 @@ export class UserService {
   async findByEmail(email: string): Promise<UserEntity | null> {
     return await this.userRepository.findOne({
       where: { email },
+    });
+  }
+
+  async findByGoogleId(googleId: string): Promise<UserEntity | null> {
+    return await this.userRepository.findOne({
+      where: { google_id: googleId },
+    });
+  }
+
+  private buildSyntheticGooglePhone(seed: string): string {
+    const digits = seed.replace(/\D/g, '').slice(-10).padStart(10, '0');
+    return `G${digits}`.slice(0, 15);
+  }
+
+  async findOrCreateGoogleUser(profile: {
+    googleId: string;
+    email: string;
+    fullName: string;
+  }): Promise<UserEntity> {
+    let user = await this.findByGoogleId(profile.googleId);
+
+    if (user) {
+      if (user.is_active === ActiveStatusEnum.INACTIVE) {
+        throw new UnauthorizedException('Your account has been disabled. Please contact support.');
+      }
+      return user;
+    }
+
+    user = await this.findByEmail(profile.email);
+    if (user) {
+      if (user.google_id && user.google_id !== profile.googleId) {
+        throw new BadRequestException('This email is linked to a different Google account');
+      }
+
+      user.google_id = profile.googleId;
+      user.full_name = user.full_name || profile.fullName;
+      user.is_otp_verified = true;
+      user.is_verified = true;
+
+      if (user.is_active === ActiveStatusEnum.INACTIVE) {
+        throw new UnauthorizedException('Your account has been disabled. Please contact support.');
+      }
+
+      return this.userRepository.save(user);
+    }
+
+    const password = await this.crypto.hashPassword(randomBytes(32).toString('hex'));
+    let phone = this.buildSyntheticGooglePhone(profile.googleId);
+    while (await this.findByPhone(phone)) {
+      phone = this.buildSyntheticGooglePhone(`${profile.googleId}-${randomBytes(4).toString('hex')}`);
+    }
+
+    return this.userRepository.save({
+      full_name: profile.fullName,
+      email: profile.email,
+      google_id: profile.googleId,
+      phone,
+      password,
+      role: RolesEnum.STUDENT,
+      is_otp_verified: true,
+      is_verified: true,
+      is_active: ActiveStatusEnum.ACTIVE,
+      refresh_token: (Math.random() * 0xfffff * 1000000).toString(16),
+      created_at: new Date(),
     });
   }
 

--- a/frontend/app/auth/google/callback/page.tsx
+++ b/frontend/app/auth/google/callback/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useToast } from "@/component/Toast/ToastContext";
+import apiClient from "@/lib/axios";
+import { RotatingLines } from "react-loader-spinner";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useRef } from "react";
+
+const GoogleCallbackContent = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { triggerToast } = useToast();
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (handledRef.current) {
+      return;
+    }
+    handledRef.current = true;
+
+    const error = searchParams.get("error");
+    if (error) {
+      triggerToast({
+        title: "Google sign-in failed",
+        description: decodeURIComponent(error),
+        type: "error",
+      });
+      router.replace("/login");
+      return;
+    }
+
+    const accessToken = searchParams.get("access_token");
+    const refreshToken = searchParams.get("refresh_token");
+    const role = searchParams.get("role");
+
+    if (!accessToken || !role) {
+      triggerToast({
+        title: "Google sign-in failed",
+        description: "Missing authentication data from Google callback.",
+        type: "error",
+      });
+      router.replace("/login");
+      return;
+    }
+
+    const completeSignIn = async () => {
+      try {
+        const payload = {
+          id: searchParams.get("id") ?? "",
+          full_name: searchParams.get("full_name") ?? "",
+          email: searchParams.get("email") ?? "",
+          phone: searchParams.get("phone") ?? "",
+          role,
+          access_token: accessToken,
+          refresh_token: refreshToken ?? "",
+        };
+
+        const setTokenResponse = await apiClient.post("/api/set-token", {
+          token: accessToken,
+          refreshToken: refreshToken ?? "",
+          role,
+        });
+
+        if (setTokenResponse.status !== 200) {
+          throw new Error("Failed to store auth session");
+        }
+
+        localStorage.setItem("user", JSON.stringify(payload));
+
+        triggerToast({
+          title: "Login Successful",
+          description: "Signed in with Google.",
+          type: "success",
+        });
+
+        if (role === "STUDENT") {
+          router.replace("/classes");
+          return;
+        }
+        if (role === "ADMIN" || role === "SUPER_ADMIN") {
+          router.replace("/admin");
+          return;
+        }
+        router.replace("/dashboard");
+      } catch {
+        triggerToast({
+          title: "Google sign-in failed",
+          description: "Unable to complete sign-in. Please try again.",
+          type: "error",
+        });
+        router.replace("/login");
+      }
+    };
+
+    void completeSignIn();
+  }, [router, searchParams, triggerToast]);
+
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <RotatingLines width="40" strokeColor="#49734F" />
+    </div>
+  );
+};
+
+const GoogleCallbackPage = () => {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[50vh] items-center justify-center">
+          <RotatingLines width="40" strokeColor="#49734F" />
+        </div>
+      }
+    >
+      <GoogleCallbackContent />
+    </Suspense>
+  );
+};
+
+export default GoogleCallbackPage;

--- a/frontend/component/Auth/ContinueWithGoogle.tsx
+++ b/frontend/component/Auth/ContinueWithGoogle.tsx
@@ -1,8 +1,22 @@
+"use client";
+
 import GoogleIconSVG from "../svg/GoogleIconSVG";
 
 const ContinueWithGoogle = () => {
+  const handleGoogleSignIn = () => {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    if (!baseUrl) {
+      return;
+    }
+    window.location.href = `${baseUrl}/auth/google`;
+  };
+
   return (
-    <button className="w-full flex items-center justify-center gap-2 bg-[#EFF0F3] py-3 rounded-lg text-[#232A25] font-normal hover:bg-gray-200 transition">
+    <button
+      type="button"
+      onClick={handleGoogleSignIn}
+      className="w-full flex items-center justify-center gap-2 bg-[#EFF0F3] py-3 rounded-lg text-[#232A25] font-normal hover:bg-gray-200 transition"
+    >
       <GoogleIconSVG width={16} />
       Continue with Google
     </button>

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -22,6 +22,11 @@ const routePolicies: RoutePolicy[] = [
     isPublic: true,
   },
   {
+    path: "/auth/google/callback",
+    match: "exact",
+    isPublic: true,
+  },
+  {
     path: "/join",
     match: "prefix",
     isPublic: true,

--- a/frontend/types/api/grading.d.ts
+++ b/frontend/types/api/grading.d.ts
@@ -112,6 +112,7 @@ interface SubmissionAnswerMatchingOrdering {
 interface SubmissionAnswerText {
   type: 'text';
   student_answer: string;
+  explanation?: string | null;
 }
 
 type SubmissionAnswer =
@@ -174,6 +175,7 @@ interface SubmissionGradingDetail {
 interface QuestionGradeInput {
   question_id: string;
   marks_obtained: number;
+  explanation?: string;
 }
 
 interface SaveSubmissionGradesPayload {


### PR DESCRIPTION
- Accept optional explanation per grade in PATCH submission grades and persist it on student_exam_answers.grader_explanation.
- Return explanation on ungraded/manual text answers in submission retrieved responses.
- Implement Google OAuth redirect flow (GET /auth/google + callback).
- Wire Continue with Google button and frontend callback page to complete session setup via set-token.