### PR TITLE
Add exam card grid breakpoints and grading results PDF export.

### DIFF
--- a/frontend/component/Classes/ClassTests.tsx
+++ b/frontend/component/Classes/ClassTests.tsx
@@ -50,7 +50,7 @@ const ClassTests = ({ testList, role }: { testList: TestListItem[]; role: RoleUs
           ))}
         </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 sm:gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-2 sm:gap-4">
         {filteredTestList.map((test) => (
           <TestCard key={test.id} testData={test} role={role} />
         ))}

--- a/frontend/component/Tests/TestList.tsx
+++ b/frontend/component/Tests/TestList.tsx
@@ -85,7 +85,7 @@ const TestList = ({ role }: TestListProps) => {
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-2 sm:gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-2 sm:gap-4">
       {filteredTestList.length > 0 &&
         filteredTestList.map((test) => (
           <TestCard key={test.id} cardBackground="white" from="testList" testData={test} role={role} />

--- a/frontend/component/grading/GradeCard.tsx
+++ b/frontend/component/grading/GradeCard.tsx
@@ -1,10 +1,13 @@
+import useDownloadExamResults from "@/hooks/api/grading/useDownloadExamResults";
 import Link from "next/link";
 import DownloadIconSVG from "../svg/DownloadIconSVG";
 import RemainingIconSVG from "../svg/RemainingIconSVG";
 import ShareIconSVG from "../svg/ShareIconSVG";
 import { getGradeCardStatusLabel, gradeCardStatusColors, gradeCardStatusTextColors } from "@/utils/grading/gradeCard";
+import ButtonLoader from "../Loader/ButtonLoadder";
 
 const GradeCard = ({ gradeItem }: GradeCardProps) => {
+  const { download, loading: isDownloading } = useDownloadExamResults();
   const status = gradeItem.grading_status;
   const statusLabel = getGradeCardStatusLabel(gradeItem.grading_status);
   const statusColor = gradeCardStatusTextColors[status];
@@ -13,6 +16,14 @@ const GradeCard = ({ gradeItem }: GradeCardProps) => {
   const submittedCount = gradeItem.submitted_count;
   const gradedCount = gradeItem.graded_count;
   const pendingCount = gradeItem.pending_count;
+
+  const handleDownloadResults = async () => {
+    if (isDownloading || submittedCount <= 0) {
+      return;
+    }
+
+    await download(gradeItem.id, gradeItem.test_name || "exam-results");
+  };
 
   return (
     <div className="rounded-[8px] bg-white p-4">
@@ -66,10 +77,13 @@ const GradeCard = ({ gradeItem }: GradeCardProps) => {
               <ShareIconSVG width={16} />
             </button>
             <button
+              type="button"
               title="Download Results"
-              className="flex h-8 w-8 items-center justify-center rounded-[8px] hover:bg-[#EFF0F3]"
+              disabled={isDownloading || submittedCount <= 0}
+              onClick={handleDownloadResults}
+              className="flex h-8 w-8 items-center justify-center rounded-[8px] hover:bg-[#EFF0F3] disabled:opacity-50"
             >
-              <DownloadIconSVG width={16} />
+              {isDownloading ? <ButtonLoader show={true} w="w-4" h="h-4" /> : <DownloadIconSVG width={16} />}
             </button>
           </div>
         )}

--- a/frontend/component/grading/GradeDetailsHeader.tsx
+++ b/frontend/component/grading/GradeDetailsHeader.tsx
@@ -1,12 +1,15 @@
 import ButtonLoader from "../Loader/ButtonLoadder";
+import useDownloadExamResults from "@/hooks/api/grading/useDownloadExamResults";
 import usePublishGradeResults from "@/hooks/api/grading/usePublishGradeResults";
 import Link from "next/link";
 import { useAppSelector } from "@/lib/hooks";
+import DownloadIconSVG from "../svg/DownloadIconSVG";
 import LeftArrowIconSVG from "../svg/LeftArrowIconSVG";
 
 const GradeDetailsHeader = ({ refetchGradeDetails }: { refetchGradeDetails: () => Promise<unknown> }) => {
   const { exam, stats } = useAppSelector((state) => state.gradeDetails);
   const [publishGradeResults, { loading: isPublishing }] = usePublishGradeResults();
+  const { download, loading: isDownloading } = useDownloadExamResults();
   const isPublishDisabled = Boolean(
     !exam?.id ||
     exam.grading_status === "PUBLISHED" ||
@@ -31,6 +34,14 @@ const GradeDetailsHeader = ({ refetchGradeDetails }: { refetchGradeDetails: () =
     await refetchGradeDetails();
   };
 
+  const handleDownloadResults = async () => {
+    if (!exam?.id || isDownloading) {
+      return;
+    }
+
+    await download(exam.id, exam.test_name || "exam-results");
+  };
+
   return (
     <>
       <Link href="/grading" className="w-max">
@@ -40,17 +51,29 @@ const GradeDetailsHeader = ({ refetchGradeDetails }: { refetchGradeDetails: () =
         </button>
       </Link>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <p className="text-[32px] font-[600] leading-[32px] tracking-[-0.04em]">{exam?.test_name || "Grade Details"}</p>
-        <button
-          type="button"
-          onClick={handlePublishResult}
-          disabled={isPublishDisabled}
-          className="flex h-[32px] w-[108px] items-center justify-center rounded-xl bg-[#49734F] text-[12px] font-[500] text-white disabled:bg-[#747775] sm:h-[40px] sm:w-[128px] sm:text-[14px]"
-        >
-          <ButtonLoader show={isPublishing} w="w-4" h="h-4" mr="mr-2" />
-          {isPublishing ? "Publishing..." : exam?.grading_status === "PUBLISHED" ? "Published" : "Publish Result"}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            title="Download Results"
+            onClick={handleDownloadResults}
+            disabled={isDownloading || !stats || stats.submissions <= 0}
+            className="flex h-[32px] w-[32px] items-center justify-center rounded-xl border border-[#E5E5E5] text-[#232A25] disabled:opacity-50 sm:h-[40px] sm:w-[40px]"
+          >
+            <ButtonLoader show={isDownloading} w="w-4" h="h-4" />
+            {!isDownloading && <DownloadIconSVG width={16} />}
+          </button>
+          <button
+            type="button"
+            onClick={handlePublishResult}
+            disabled={isPublishDisabled}
+            className="flex h-[32px] w-[108px] items-center justify-center rounded-xl bg-[#49734F] text-[12px] font-[500] text-white disabled:bg-[#747775] sm:h-[40px] sm:w-[128px] sm:text-[14px]"
+          >
+            <ButtonLoader show={isPublishing} w="w-4" h="h-4" mr="mr-2" />
+            {isPublishing ? "Publishing..." : exam?.grading_status === "PUBLISHED" ? "Published" : "Publish Result"}
+          </button>
+        </div>
       </div>
     </>
   );

--- a/frontend/hooks/api/grading/useDownloadExamResults.ts
+++ b/frontend/hooks/api/grading/useDownloadExamResults.ts
@@ -1,0 +1,47 @@
+import { useToast } from "@/component/Toast/ToastContext";
+import { downloadExamResultsPdf } from "@/utils/exam/downloadExamResultsPdf";
+import { fetchAllGradingSubmissions } from "@/utils/grading/fetchAllGradingSubmissions";
+import { AxiosError } from "axios";
+import { useCallback, useState } from "react";
+import { useApiError } from "../useApiError";
+
+const useDownloadExamResults = () => {
+  const { triggerToast } = useToast();
+  const { handleError } = useApiError();
+  const [loading, setLoading] = useState(false);
+
+  const download = useCallback(
+    async (examId: string, testName: string) => {
+      setLoading(true);
+
+      try {
+        const { exam, submissions } = await fetchAllGradingSubmissions(examId);
+
+        if (submissions.length === 0) {
+          triggerToast({
+            title: "No results available",
+            description: "There are no student submissions to download yet.",
+            type: "error",
+          });
+          return;
+        }
+
+        await downloadExamResultsPdf({
+          testName: testName || exam.test_name || "exam-results",
+          className: exam.class_name,
+          subject: exam.subject,
+          submissions,
+        });
+      } catch (error) {
+        handleError(error as AxiosError<ApiError>);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [handleError, triggerToast],
+  );
+
+  return { download, loading } as const;
+};
+
+export default useDownloadExamResults;

--- a/frontend/utils/exam/downloadExamResultsPdf.ts
+++ b/frontend/utils/exam/downloadExamResultsPdf.ts
@@ -1,0 +1,32 @@
+import { jsPDF } from "jspdf";
+import { loadPdfAssets } from "./pdf/loadPdfAssets";
+import { addWatermark, PDF_PAGE_MARGIN } from "./pdf/pdfLayout";
+import { renderGradingResultsTable } from "./pdf/renderGradingResultsTable";
+import { renderResultsPdfHeader } from "./pdf/renderResultsPdfHeader";
+import { setPdfLatinFont } from "./pdf/renderPdfText";
+
+export interface DownloadExamResultsPdfOptions {
+  testName: string;
+  className: string | null;
+  subject: string | null;
+  submissions: GradingSubmissionListItem[];
+}
+
+export const downloadExamResultsPdf = async (options: DownloadExamResultsPdfOptions): Promise<void> => {
+  const assets = await loadPdfAssets();
+  const doc = new jsPDF({ unit: "mm", format: "a4" });
+  setPdfLatinFont(doc, "normal");
+
+  let y = PDF_PAGE_MARGIN;
+  y = await renderResultsPdfHeader(doc, y, {
+    className: options.className,
+    subject: options.subject,
+    logoBase64: assets.logoBase64,
+  });
+
+  y = await renderGradingResultsTable(doc, y, options.submissions);
+
+  addWatermark(doc);
+  const safeName = (options.testName || "exam-results").replace(/[^\w\s-]/g, "").trim().replace(/\s+/g, "-");
+  doc.save(`${safeName}-results.pdf`);
+};

--- a/frontend/utils/exam/pdf/renderGradingResultsTable.ts
+++ b/frontend/utils/exam/pdf/renderGradingResultsTable.ts
@@ -1,0 +1,170 @@
+import type { jsPDF } from "jspdf";
+import { ensureSpace, getContentWidth, PDF_LINE_HEIGHT, PDF_PAGE_MARGIN } from "./pdfLayout";
+import { renderPdfTextBlock, setPdfLatinFont } from "./renderPdfText";
+
+const TABLE_ROW_MIN_HEIGHT = 8;
+const TABLE_HEADER_HEIGHT = 10;
+
+const TABLE_COLUMNS = {
+  serial: { label: "SL", widthRatio: 0.08 },
+  name: { label: "Student Name", widthRatio: 0.42 },
+  phone: { label: "Phone Number", widthRatio: 0.28 },
+  marks: { label: "Marks Obtained", widthRatio: 0.22 },
+} as const;
+
+const getColumnLayout = (contentWidth: number) => {
+  const serialWidth = contentWidth * TABLE_COLUMNS.serial.widthRatio;
+  const nameWidth = contentWidth * TABLE_COLUMNS.name.widthRatio;
+  const phoneWidth = contentWidth * TABLE_COLUMNS.phone.widthRatio;
+  const marksWidth = contentWidth * TABLE_COLUMNS.marks.widthRatio;
+
+  const serialX = PDF_PAGE_MARGIN;
+  const nameX = serialX + serialWidth;
+  const phoneX = nameX + nameWidth;
+  const marksX = phoneX + phoneWidth;
+
+  return {
+    serial: { x: serialX, width: serialWidth },
+    name: { x: nameX, width: nameWidth },
+    phone: { x: phoneX, width: phoneWidth },
+    marks: { x: marksX, width: marksWidth },
+  };
+};
+
+const drawTableBorder = (doc: jsPDF, y: number, height: number, contentWidth: number): void => {
+  doc.setDrawColor(180, 180, 180);
+  doc.setLineWidth(0.2);
+  doc.rect(PDF_PAGE_MARGIN, y, contentWidth, height);
+};
+
+const formatMarks = (submission: GradingSubmissionListItem): string => {
+  if (submission.total_score === null || submission.total_score === undefined) {
+    return "-";
+  }
+
+  return String(submission.total_score);
+};
+
+const formatPhone = (submission: GradingSubmissionListItem): string => {
+  return submission.phone?.trim() || "-";
+};
+
+const renderLatinCell = (
+  doc: jsPDF,
+  text: string,
+  x: number,
+  y: number,
+  width: number,
+  align: "left" | "center" | "right" = "left",
+): number => {
+  setPdfLatinFont(doc, "normal");
+  doc.setFontSize(10);
+  const lines = doc.splitTextToSize(text, width - 4) as string[];
+  const textY = y + 5;
+
+  if (align === "center") {
+    doc.text(lines, x + width / 2, textY, { align: "center", maxWidth: width - 4 });
+  } else if (align === "right") {
+    doc.text(lines, x + width - 2, textY, { align: "right", maxWidth: width - 4 });
+  } else {
+    doc.text(lines, x + 2, textY, { maxWidth: width - 4 });
+  }
+
+  return lines.length * PDF_LINE_HEIGHT + 4;
+};
+
+const renderTableHeader = (doc: jsPDF, y: number, contentWidth: number): number => {
+  const columns = getColumnLayout(contentWidth);
+  let cursorY = ensureSpace(doc, y, TABLE_HEADER_HEIGHT);
+
+  setPdfLatinFont(doc, "bold");
+  doc.setFontSize(10);
+  doc.text(TABLE_COLUMNS.serial.label, columns.serial.x + 2, cursorY + 6);
+  doc.text(TABLE_COLUMNS.name.label, columns.name.x + 2, cursorY + 6);
+  doc.text(TABLE_COLUMNS.phone.label, columns.phone.x + 2, cursorY + 6);
+  doc.text(TABLE_COLUMNS.marks.label, columns.marks.x + columns.marks.width / 2, cursorY + 6, {
+    align: "center",
+  });
+
+  drawTableBorder(doc, cursorY, TABLE_HEADER_HEIGHT, contentWidth);
+  cursorY += TABLE_HEADER_HEIGHT;
+
+  doc.setDrawColor(180, 180, 180);
+  doc.line(columns.name.x, cursorY - TABLE_HEADER_HEIGHT, columns.name.x, cursorY);
+  doc.line(columns.phone.x, cursorY - TABLE_HEADER_HEIGHT, columns.phone.x, cursorY);
+  doc.line(columns.marks.x, cursorY - TABLE_HEADER_HEIGHT, columns.marks.x, cursorY);
+
+  return cursorY;
+};
+
+const renderTableRow = async (
+  doc: jsPDF,
+  y: number,
+  serial: number,
+  submission: GradingSubmissionListItem,
+  contentWidth: number,
+): Promise<number> => {
+  const columns = getColumnLayout(contentWidth);
+  let cursorY = ensureSpace(doc, y, TABLE_ROW_MIN_HEIGHT);
+  const rowTop = cursorY;
+
+  const serialHeight = renderLatinCell(doc, String(serial), columns.serial.x, rowTop, columns.serial.width, "center");
+  const phoneHeight = renderLatinCell(
+    doc,
+    formatPhone(submission),
+    columns.phone.x,
+    rowTop,
+    columns.phone.width,
+  );
+  const marksHeight = renderLatinCell(
+    doc,
+    formatMarks(submission),
+    columns.marks.x,
+    rowTop,
+    columns.marks.width,
+    "center",
+  );
+
+  const nameText = submission.student_name?.trim() || "Anonymous";
+  const nameEndY = await renderPdfTextBlock(
+    doc,
+    nameText,
+    columns.name.x + 2,
+    rowTop + 4,
+    columns.name.width - 4,
+    PDF_LINE_HEIGHT,
+    { fontSize: 10 },
+  );
+  const nameHeight = nameEndY - rowTop;
+
+  const rowHeight = Math.max(TABLE_ROW_MIN_HEIGHT, serialHeight, phoneHeight, marksHeight, nameHeight);
+  drawTableBorder(doc, rowTop, rowHeight, contentWidth);
+
+  doc.setDrawColor(180, 180, 180);
+  doc.line(columns.name.x, rowTop, columns.name.x, rowTop + rowHeight);
+  doc.line(columns.phone.x, rowTop, columns.phone.x, rowTop + rowHeight);
+  doc.line(columns.marks.x, rowTop, columns.marks.x, rowTop + rowHeight);
+
+  return rowTop + rowHeight;
+};
+
+export const renderGradingResultsTable = async (
+  doc: jsPDF,
+  y: number,
+  submissions: GradingSubmissionListItem[],
+): Promise<number> => {
+  const contentWidth = getContentWidth(doc);
+  let cursorY = renderTableHeader(doc, y, contentWidth);
+
+  const sortedSubmissions = [...submissions].sort((left, right) => {
+    const leftName = (left.student_name ?? "").trim().toLowerCase();
+    const rightName = (right.student_name ?? "").trim().toLowerCase();
+    return leftName.localeCompare(rightName);
+  });
+
+  for (const [index, submission] of sortedSubmissions.entries()) {
+    cursorY = await renderTableRow(doc, cursorY, index + 1, submission, contentWidth);
+  }
+
+  return cursorY + 4;
+};

--- a/frontend/utils/exam/pdf/renderResultsPdfHeader.ts
+++ b/frontend/utils/exam/pdf/renderResultsPdfHeader.ts
@@ -1,0 +1,42 @@
+import type { jsPDF } from "jspdf";
+import { ensureSpace, PDF_LINE_HEIGHT, PDF_PAGE_MARGIN } from "./pdfLayout";
+import { getPdfClassLabel } from "./pdfSectionMessages";
+import { renderPdfTextBlock } from "./renderPdfText";
+
+export interface RenderResultsPdfHeaderOptions {
+  className: string | null;
+  subject: string | null;
+  logoBase64: string;
+}
+
+export const renderResultsPdfHeader = async (
+  doc: jsPDF,
+  y: number,
+  options: RenderResultsPdfHeaderOptions,
+): Promise<number> => {
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const contentWidth = pageWidth - PDF_PAGE_MARGIN * 2;
+  let cursorY = y;
+
+  const logoSize = 14;
+  doc.addImage(options.logoBase64, "PNG", pageWidth / 2 - logoSize / 2, cursorY, logoSize, logoSize);
+  cursorY += logoSize + 6;
+
+  const classLabel = getPdfClassLabel(options.className);
+  cursorY = ensureSpace(doc, cursorY, PDF_LINE_HEIGHT * 4);
+  cursorY = await renderPdfTextBlock(doc, classLabel, pageWidth / 2, cursorY, contentWidth, PDF_LINE_HEIGHT + 2, {
+    fontSize: 18,
+    style: "bold",
+    align: "center",
+  });
+
+  const subjectLabel = options.subject?.trim() || "Subject";
+  cursorY = ensureSpace(doc, cursorY, PDF_LINE_HEIGHT * 3);
+  cursorY = await renderPdfTextBlock(doc, subjectLabel, pageWidth / 2, cursorY, contentWidth, PDF_LINE_HEIGHT + 2, {
+    fontSize: 14,
+    style: "bold",
+    align: "center",
+  });
+
+  return cursorY + 8;
+};

--- a/frontend/utils/grading/fetchAllGradingSubmissions.ts
+++ b/frontend/utils/grading/fetchAllGradingSubmissions.ts
@@ -1,0 +1,47 @@
+import axiosReq from "@/lib/axios";
+import { AxiosResponse } from "axios";
+
+const GRADING_EXPORT_PAGE_LIMIT = 50;
+
+export interface FetchAllGradingSubmissionsResult {
+  exam: GradingExamSummary;
+  submissions: GradingSubmissionListItem[];
+}
+
+export const fetchAllGradingSubmissions = async (examId: string): Promise<FetchAllGradingSubmissionsResult> => {
+  let page = 1;
+  let exam: GradingExamSummary | null = null;
+  const submissions: GradingSubmissionListItem[] = [];
+
+  while (true) {
+    const response = await axiosReq.get<GradingSummaryResponse, AxiosResponse<GradingSummaryResponse>>(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/exams/grading/${examId}`,
+      {
+        params: {
+          page,
+          limit: GRADING_EXPORT_PAGE_LIMIT,
+        },
+      },
+    );
+
+    if (response.status !== 200) {
+      break;
+    }
+
+    exam = response.data.payload.exam;
+    submissions.push(...response.data.payload.submissions);
+
+    const totalPages = response.data.meta.total_pages;
+    if (page >= totalPages) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  if (!exam) {
+    throw new Error("Exam not found");
+  }
+
+  return { exam, submissions };
+};


### PR DESCRIPTION
Show two test cards per row on laptop screens and three on 2xl+, and let teachers download a results PDF with logo header and student marks table from grading list and detail pages.